### PR TITLE
Added the 2024 RAM HD changes for the new cruise button location

### DIFF
--- a/opendbc/dbc/chrysler_ram_hd_generated.dbc
+++ b/opendbc/dbc/chrysler_ram_hd_generated.dbc
@@ -137,6 +137,18 @@ BO_ 570 CRUISE_BUTTONS: 3 XXX
  SG_ COUNTER : 15|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 23|8@0+ (1,0) [0|255] "" XXX
 
+BO_ 571 CRUISE_BUTTONS_ALT: 3 XXX
+ SG_ ACC_Cancel : 0|1@1+ (1,0) [0|0] "" XXX
+ SG_ ACC_Distance_Dec : 1|1@1+ (1,0) [0|0] "" XXX
+ SG_ ACC_Accel : 2|1@1+ (1,0) [0|0] "" XXX
+ SG_ ACC_Decel : 3|1@1+ (1,0) [0|0] "" XXX
+ SG_ ACC_Resume : 4|1@0+ (1,0) [0|1] "" XXX
+ SG_ Cruise_OnOff : 6|1@1+ (1,0) [0|0] "" XXX
+ SG_ ACC_OnOff : 7|1@1+ (1,0) [0|0] "" XXX
+ SG_ ACC_Distance_Inc : 8|1@1+ (1,0) [0|0] "" XXX
+ SG_ COUNTER : 15|4@0+ (1,0) [0|15] "" XXX
+ SG_ CHECKSUM : 23|8@0+ (1,0) [0|255] "" XXX
+
 BO_ 625 DAS_5: 8 XXX
  SG_ FCW_STATE : 2|1@1+ (1,0) [0|0] ""  XXX
  SG_ FCW_DISTANCE : 3|2@1+ (1,0) [0|0] ""  XXX


### PR DESCRIPTION
This adds the new alternate cruise buttons for the 2024 Ram HDs. The 2024 Ram HDs use the same buttons as the 1500s now. 