### PR TITLE
Refactor Hyundai ACC command generation functions

### DIFF
--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -2,7 +2,7 @@ from opendbc.can.packer import CANPacker
 from opendbc.car import DT_CTRL, apply_driver_steer_torque_limits, common_fault_avoidance, make_tester_present_msg, structs
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.common.numpy_fast import clip
-from opendbc.car.hyundai import hyundaicanfd, hyundaican
+from opendbc.car.hyundai import hyundaicanfd, hyundaican, hyundaicansp
 from opendbc.car.hyundai.carstate import CarState
 from opendbc.car.hyundai.hyundaicanfd import CanBus
 from opendbc.car.hyundai.values import HyundaiFlags, Buttons, CarControllerParams, CAR
@@ -145,9 +145,9 @@ class CarController(CarControllerBase):
         # TODO: unclear if this is needed
         jerk = 3.0 if actuators.longControlState == LongCtrlState.pid else 1.0
         use_fca = self.CP.flags & HyundaiFlags.USE_FCA.value
-        can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2),
+        can_sends.extend(hyundaicansp.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2),
                                                         hud_control, set_speed_in_units, stopping,
-                                                        CC.cruiseControl.override, use_fca))
+                                                        CC.cruiseControl.override, use_fca, CS))
 
       # 20 Hz LFA MFA message
       if self.frame % 5 == 0 and self.CP.flags & HyundaiFlags.SEND_LFA.value:

--- a/opendbc/car/hyundai/hyundaicansp.py
+++ b/opendbc/car/hyundai/hyundaicansp.py
@@ -1,0 +1,31 @@
+from opendbc.car.hyundai import hyundaican
+from opendbc.car.hyundai.hyundaican import get_scc11_values, calculate_scc12_checksum, \
+    get_scc14_values, get_fca11_values, calculate_fca11_checksum
+from sunnypilot.car.hyundai import escc
+
+
+def get_scc12_values(enabled, accel, idx, stopping, long_override, use_fca, CS):
+    scc12_values = hyundaican.get_scc12_values(enabled, accel, idx, stopping, long_override, use_fca)
+    scc12_values = escc.update_escc_values(scc12_values, CS)
+    return scc12_values
+
+
+def create_acc_commands(packer, enabled, accel, upper_jerk, idx, hud_control, set_speed, stopping, long_override, use_fca, CS):
+    commands = []
+
+    scc11_values = get_scc11_values(enabled, set_speed, idx, hud_control)
+    commands.append(packer.make_can_msg("SCC11", 0, scc11_values))
+
+    scc12_values = get_scc12_values(enabled, accel, idx, stopping, long_override, use_fca, CS)
+    scc12_values = calculate_scc12_checksum(packer, scc12_values)
+    commands.append(packer.make_can_msg("SCC12", 0, scc12_values))
+
+    scc14_values = get_scc14_values(enabled, upper_jerk, hud_control, long_override)
+    commands.append(packer.make_can_msg("SCC14", 0, scc14_values))
+
+    if use_fca:
+        fca11_values = get_fca11_values(idx)
+        fca11_values = calculate_fca11_checksum(packer, fca11_values)
+        commands.append(packer.make_can_msg("FCA11", 0, fca11_values))
+
+    return commands


### PR DESCRIPTION
Streamlined ACC command generation by breaking down functions into smaller, reusable components. Introduced new code in `escc.py` for updating additional SCC12 values and consolidated the logic into `hyundaicansp.py`. Updated imports and usages accordingly in `carcontroller.py` for cleaner and more maintainable code.