### PR TITLE
Car Port: Genesis GV70 2.5T 2025 korea (HDA1) 

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1078,11 +1078,13 @@ FW_VERSIONS = {
       b'\xf1\x00JK1 MFC  AT USA LHD 1.00 1.01 99211-AR200 220125',
       b'\xf1\x00JK1 MFC  AT USA LHD 1.00 1.01 99211-AR300 220125',
       b'\xf1\x00JK1 MFC  AT USA LHD 1.00 1.04 99211-AR000 210204',
+      b'\xf1\x00JK  MFC  AT KOR LHD 1.00 1.00 99211-AR500 240311',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00JK1_ SCC FHCUP      1.00 1.00 99110-AR200         ',
       b'\xf1\x00JK1_ SCC FHCUP      1.00 1.00 99110-AR300         ',
       b'\xf1\x00JK1_ SCC FHCUP      1.00 1.02 99110-AR000         ',
+      b'\xf1\x00JK__ RDR -----      1.00 1.01 99110-AR500         ',
     ],
   },
   CAR.GENESIS_GV70_ELECTRIFIED_1ST_GEN: {


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Support for Genesis GV70 2.5T 2025 Korea has been added.