### PR TITLE
Refactor `get_non_essential_params_sp` to simplify arguments

### DIFF
--- a/opendbc/car/body/interface.py
+++ b/opendbc/car/body/interface.py
@@ -23,8 +23,3 @@ class CarInterface(CarInterfaceBase):
     ret.steerControlType = structs.CarParams.SteerControlType.angle
 
     return ret
-
-  @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -173,7 +173,7 @@ def get_car(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_multip
   CP.carFw = car_fw
   CP.fingerprintSource = source
   CP.fuzzyFingerprint = not exact_match
-  CP, CP_SP = CarInterface.get_params_sp(CP, candidate, fingerprints, car_fw, experimental_long_allowed, docs=False)
+  CP_SP = CarInterface.get_params_sp(CP, candidate, fingerprints, car_fw, experimental_long_allowed, docs=False)
 
   return get_car_interface(CP, CP_SP)
 

--- a/opendbc/car/chrysler/interface.py
+++ b/opendbc/car/chrysler/interface.py
@@ -72,8 +72,3 @@ class CarInterface(CarInterfaceBase):
     ret.enableBsm = 720 in fingerprint[0]
 
     return ret
-
-  @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret

--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -81,8 +81,3 @@ class CarInterface(CarInterfaceBase):
     ret.autoResumeSng = ret.minEnableSpeed == -1.
     ret.centerToFront = ret.wheelbase * 0.44
     return ret
-
-  @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret

--- a/opendbc/car/gm/interface.py
+++ b/opendbc/car/gm/interface.py
@@ -214,8 +214,3 @@ class CarInterface(CarInterfaceBase):
       ret.dashcamOnly = True  # Needs steerRatio, tireStiffness, and lat accel factor tuning
 
     return ret
-
-  @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret

--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -211,11 +211,6 @@ class CarInterface(CarInterfaceBase):
     return ret
 
   @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret
-
-  @staticmethod
   def init(CP, CP_SP, can_recv, can_send):
     if CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS) and CP.openpilotLongitudinalControl:
       disable_ecu(can_recv, can_send, bus=CanBus(CP).pt, addr=0x18DAB0F1, com_cont_req=b'\x28\x83\x03')

--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -133,9 +133,7 @@ class CarInterface(CarInterfaceBase):
   @staticmethod
   def _get_params_sp(stock_cp: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
                      car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> structs.CarParamsSP:
-    if stock_cp.flags & HyundaiFlags.CANFD:
-      pass
-    else:
+    if not stock_cp.flags & HyundaiFlags.CANFD:
       # TODO-SP: add route with ESCC message for process replay
       if ESCC_MSG in fingerprint[0]:
         ret.flags |= HyundaiFlagsSP.ENHANCED_SCC.value

--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -131,9 +131,9 @@ class CarInterface(CarInterfaceBase):
     return ret
 
   @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    if ret_stock.flags & HyundaiFlags.CANFD:
+  def _get_params_sp(stock_cp: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
+                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> structs.CarParamsSP:
+    if stock_cp.flags & HyundaiFlags.CANFD:
       pass
     else:
       # TODO-SP: add route with ESCC message for process replay
@@ -144,10 +144,10 @@ class CarInterface(CarInterfaceBase):
         ret.flags |= HyundaiFlagsSP.HAS_LFA_BUTTON.value
 
     if ret.flags & HyundaiFlagsSP.ENHANCED_SCC:
-      ret_stock.safetyConfigs[-1].safetyParam |= Panda.FLAG_HYUNDAI_ESCC
-      ret_stock.radarUnavailable = False
+      stock_cp.safetyConfigs[-1].safetyParam |= Panda.FLAG_HYUNDAI_ESCC
+      stock_cp.radarUnavailable = False
 
-    return ret_stock, ret
+    return ret
 
   @staticmethod
   def init(CP, CP_SP, can_recv, can_send):

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -116,10 +116,8 @@ class CarInterfaceBase(ABC):
     return cls.get_params(candidate, gen_empty_fingerprint(), list(), False, False)
 
   @classmethod
-  def get_non_essential_params_sp(cls, candidate: str) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    stock_cp = cls.get_non_essential_params(candidate)
-    sp_cp = cls.get_params_sp(stock_cp, candidate, gen_empty_fingerprint(), list(), False, False)
-    return stock_cp, sp_cp
+  def get_non_essential_params_sp(cls, car_params, candidate: str) -> structs.CarParamsSP:
+    return cls.get_params_sp(car_params, candidate, gen_empty_fingerprint(), list(), False, False)
 
   @classmethod
   def get_params(cls, candidate: str, fingerprint: dict[int, dict[int, int]], car_fw: list[structs.CarParams.CarFw],
@@ -147,10 +145,13 @@ class CarInterfaceBase(ABC):
     ret.tireStiffnessFront, ret.tireStiffnessRear = scale_tire_stiffness(ret.mass, ret.wheelbase, ret.centerToFront, ret.tireStiffnessFactor)
 
     return ret
+
   @classmethod
-  def get_params_sp(cls, ret_stock, candidate: str, fingerprint: dict[int, dict[int, int]], car_fw: list[structs.CarParams.CarFw], experimental_long: bool,
+  def get_params_sp(cls, car_params, candidate: str, fingerprint: dict[int, dict[int, int]], car_fw: list[structs.CarParams.CarFw], experimental_long: bool,
                     docs: bool) -> structs.CarParamsSP:
-    return cls._get_params_sp(ret_stock, structs.CarParamsSP(), candidate, fingerprint, car_fw, experimental_long, docs)
+    car_params_sp = structs.CarParamsSP()
+
+    return cls._get_params_sp(car_params, car_params_sp, candidate, fingerprint, car_fw, experimental_long, docs)
 
   @staticmethod
   @abstractmethod

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -159,7 +159,6 @@ class CarInterfaceBase(ABC):
     raise NotImplementedError
 
   @staticmethod
-  @abstractmethod
   def _get_params_sp(stock_cp: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
                      car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> structs.CarParamsSP:
     print(f"Car {candidate} does not have a _get_params_sp method, using defaults")

--- a/opendbc/car/mazda/interface.py
+++ b/opendbc/car/mazda/interface.py
@@ -27,8 +27,3 @@ class CarInterface(CarInterfaceBase):
     ret.centerToFront = ret.wheelbase * 0.41
 
     return ret
-
-  @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret

--- a/opendbc/car/mock/interface.py
+++ b/opendbc/car/mock/interface.py
@@ -15,8 +15,3 @@ class CarInterface(CarInterfaceBase):
     ret.steerRatio = 13.
     ret.dashcamOnly = True
     return ret
-
-  @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret

--- a/opendbc/car/nissan/interface.py
+++ b/opendbc/car/nissan/interface.py
@@ -28,8 +28,3 @@ class CarInterface(CarInterfaceBase):
       ret.safetyConfigs[-1].safetyParam |= Panda.FLAG_NISSAN_LEAF
 
     return ret
-
-  @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret

--- a/opendbc/car/subaru/interface.py
+++ b/opendbc/car/subaru/interface.py
@@ -95,11 +95,6 @@ class CarInterface(CarInterfaceBase):
     return ret
 
   @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret
-
-  @staticmethod
   def init(CP, CP_SP, can_recv, can_send):
     if CP.flags & SubaruFlags.DISABLE_EYESIGHT:
       disable_ecu(can_recv, can_send, bus=2, addr=GLOBAL_ES_ADDR, com_cont_req=b'\x28\x03\x01')

--- a/opendbc/car/tesla/interface.py
+++ b/opendbc/car/tesla/interface.py
@@ -25,8 +25,3 @@ class CarInterface(CarInterfaceBase):
     ret.openpilotLongitudinalControl = True
 
     return ret
-
-  @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret

--- a/opendbc/car/tests/test_car_interfaces.py
+++ b/opendbc/car/tests/test_car_interfaces.py
@@ -59,7 +59,7 @@ class TestCarInterfaces:
 
     car_params = CarInterface.get_params(car_name, args['fingerprints'], args['car_fw'],
                                          experimental_long=args['experimental_long'], docs=False)
-    car_params, car_params_sp = CarInterface.get_params_sp(car_params, car_name, args['fingerprints'], args['car_fw'],
+    car_params_sp = CarInterface.get_params_sp(car_params, car_name, args['fingerprints'], args['car_fw'],
                                                            experimental_long=args['experimental_long'], docs=False)
     car_interface = CarInterface(car_params, car_params_sp, CarController, CarState)
     assert car_params

--- a/opendbc/car/toyota/interface.py
+++ b/opendbc/car/toyota/interface.py
@@ -146,11 +146,6 @@ class CarInterface(CarInterfaceBase):
     return ret
 
   @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret
-
-  @staticmethod
   def init(CP, CP_SP, can_recv, can_send):
     # disable radar if alpha longitudinal toggled on radar-ACC car
     if CP.flags & ToyotaFlags.DISABLE_RADAR.value:

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -158,7 +158,6 @@ class CarState(CarStateBase):
 
     self.frame += 1
     return ret
-
   def update_pq(self, pt_cp, cam_cp, ext_cp) -> structs.CarState:
     ret = structs.CarState()
     # Update vehicle speed and acceleration from ABS wheel speeds.
@@ -257,7 +256,6 @@ class CarState(CarStateBase):
 
     self.frame += 1
     return ret
-
   def update_hca_state(self, hca_status):
     # Treat INITIALIZING and FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     # DISABLED means the EPS hasn't been configured to support Lane Assist

--- a/opendbc/car/volkswagen/interface.py
+++ b/opendbc/car/volkswagen/interface.py
@@ -84,8 +84,3 @@ class CarInterface(CarInterfaceBase):
     ret.autoResumeSng = ret.minEnableSpeed == -1
 
     return ret
-
-  @staticmethod
-  def _get_params_sp(ret_stock: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
-                     car_fw: list[structs.CarParams.CarFw], experimental_long: bool, docs: bool) -> tuple[structs.CarParams, structs.CarParamsSP]:
-    return ret_stock, ret


### PR DESCRIPTION
Simplify the method by removing redundant input arguments and adjusting its return structure. These changes improve readability and maintain consistency with other related methods. Adjustments are also reflected in the corresponding test and process replay code.

## Summary by Sourcery

Refactor the `get_non_essential_params_sp` method to simplify its arguments and return a tuple containing both CarParams and CarParamsSP objects. Update callsites and tests accordingly.

Enhancements:
- Simplify the `get_non_essential_params_sp` method by removing redundant input arguments.

Tests:
- Update tests to reflect the changes in `get_non_essential_params_sp`