### PR TITLE
MADS: Safety migration fixes

### DIFF
--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -789,7 +789,7 @@ bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const
   }
 
   // No angle control allowed when controls are not allowed
-  violation |= !controls_allowed && steer_control_enabled;
+  violation |= !is_lat_active() && steer_control_enabled;
 
   return violation;
 }

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -8,7 +8,8 @@ from collections.abc import Callable
 from opendbc.can.packer import CANPacker  # pylint: disable=import-error
 from opendbc.safety import ALTERNATIVE_EXPERIENCE
 from opendbc.safety.tests.libsafety import libsafety_py
-from opendbc.safety.tests.mads_common import MadsCommonBase
+
+from opendbc.safety.tests.mads_common import MadsSafetyTestBase
 
 MAX_WRONG_COUNTERS = 5
 MAX_SAMPLE_VALS = 6
@@ -817,7 +818,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
 
 
 @add_regen_tests
-class PandaCarSafetyTest(PandaSafetyTest, MadsCommonBase):
+class PandaCarSafetyTest(PandaSafetyTest, MadsSafetyTestBase):
   STANDSTILL_THRESHOLD: float = 0.0
   GAS_PRESSED_THRESHOLD = 0
   RELAY_MALFUNCTION_ADDRS: dict[int, tuple[int, ...]] | None = None

--- a/opendbc/safety/tests/mads_common.py
+++ b/opendbc/safety/tests/mads_common.py
@@ -416,3 +416,5 @@ class MadsSafetyTestBase(unittest.TestCase):
 
     finally:
       self._mads_states_cleanup()
+
+  # TODO-SP: controls_allowed and controls_allowed_lat check for steering safety tests

--- a/opendbc/safety/tests/mads_common.py
+++ b/opendbc/safety/tests/mads_common.py
@@ -1,13 +1,17 @@
+import abc
 import unittest
-from abc import abstractmethod
+
+from opendbc.safety.tests.libsafety import libsafety_py
 
 
-class MadsCommonBase(unittest.TestCase):
-  @abstractmethod
+class MadsSafetyTestBase(unittest.TestCase):
+  safety: libsafety_py.Panda
+
+  @abc.abstractmethod
   def _lkas_button_msg(self, enabled):
     raise NotImplementedError
 
-  @abstractmethod
+  @abc.abstractmethod
   def _acc_state_msg(self, enabled):
     raise NotImplementedError
 


### PR DESCRIPTION
Introduced in https://github.com/sunnypilot/opendbc/pull/67, some changes for MADS were not migrated over correctly.

## Summary by Sourcery

Fixes issues introduced in a previous pull request related to MADS safety by ensuring correct migration of changes. This includes changes to steering angle command checks and updates to the base classes for MADS safety tests.

Enhancements:
- Updates steering angle command checks to use `is_lat_active()` instead of `controls_allowed` to determine lateral control availability.
- Refactors MADS safety tests to use a new base class `MadsSafetyTestBase` and introduces abstract methods for LKAS button and ACC state messages.
- Updates `PandaCarSafetyTest` to inherit from `MadsSafetyTestBase` instead of `MadsCommonBase`

Tests:
- Adds a TODO comment for steering safety tests to check `controls_allowed` and `controls_allowed_lat`.