### PR TITLE
Sync: `commaai/opendbc:master` into `sunnypilot/opendbc:master-new`

### DIFF
--- a/opendbc/car/body/interface.py
+++ b/opendbc/car/body/interface.py
@@ -1,10 +1,15 @@
 import math
 from opendbc.car import get_safety_config, structs
-from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.body.carcontroller import CarController
+from opendbc.car.body.carstate import CarState
 from opendbc.car.body.values import SPEED_FROM_RPM
+from opendbc.car.interfaces import CarInterfaceBase
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:
     ret.notCar = True

--- a/opendbc/car/body/radar_interface.py
+++ b/opendbc/car/body/radar_interface.py
@@ -1,4 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -300,13 +300,14 @@ struct CarState {
 # ******* radar state @ 20hz *******
 
 struct RadarData @0x888ad6581cf0aacb {
-  errors @0 :List(Error);
+  errors @3 :Error;
   points @1 :List(RadarPoint);
 
-  enum Error {
-    canError @0;
-    fault @1;
-    wrongConfig @2;
+  struct Error {
+    canError @0 :Bool;
+    radarFault @1 :Bool;
+    wrongConfig @2 :Bool;
+    radarUnavailableTemporary @3 :Bool;  # radar data is temporarily unavailable due to conditions the car sets
   }
 
   # similar to LiveTracks
@@ -327,8 +328,15 @@ struct RadarData @0x888ad6581cf0aacb {
     measured @6 :Bool;
   }
 
+  enum ErrorDEPRECATED {
+    canError @0;
+    fault @1;
+    wrongConfig @2;
+  }
+
   # deprecated
   canMonoTimesDEPRECATED @2 :List(UInt64);
+  errorsDEPRECATED @0 :List(ErrorDEPRECATED);
 }
 
 # ******* car controls @ 100hz *******

--- a/opendbc/car/chrysler/interface.py
+++ b/opendbc/car/chrysler/interface.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
 from opendbc.car import get_safety_config, structs
+from opendbc.car.chrysler.carcontroller import CarController
+from opendbc.car.chrysler.carstate import CarState
+from opendbc.car.chrysler.radar_interface import RadarInterface
 from opendbc.car.chrysler.values import CAR, RAM_HD, RAM_DT, RAM_CARS, ChryslerFlags, ChryslerSafetyFlags
 from opendbc.car.interfaces import CarInterfaceBase
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+  RadarInterface = RadarInterface
+
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:
     ret.brand = "chrysler"

--- a/opendbc/car/chrysler/radar_interface.py
+++ b/opendbc/car/chrysler/radar_interface.py
@@ -53,10 +53,8 @@ class RadarInterface(RadarInterfaceBase):
       return None
 
     ret = structs.RadarData()
-    errors = []
     if not self.rcp.can_valid:
-      errors.append("canError")
-    ret.errors = errors
+      ret.errors.canError = True
 
     for ii in self.updated_messages:  # ii should be the message ID as a number
       cpt = self.rcp.vl[ii]

--- a/opendbc/car/docs.py
+++ b/opendbc/car/docs.py
@@ -30,9 +30,9 @@ EXTRA_PLATFORMS: dict[str, ExtraPlatform] = {str(platform): platform for brand i
 
 def get_params_for_docs(platform) -> CarParams:
   cp_platform = platform if platform in interfaces else MOCK.MOCK
-  CP: CarParams = interfaces[cp_platform][0].get_params(cp_platform, fingerprint=gen_empty_fingerprint(),
-                                                        car_fw=[CarParams.CarFw(ecu=CarParams.Ecu.unknown)],
-                                                        experimental_long=True, docs=True)
+  CP: CarParams = interfaces[cp_platform].get_params(cp_platform, fingerprint=gen_empty_fingerprint(),
+                                                     car_fw=[CarParams.CarFw(ecu=CarParams.Ecu.unknown)],
+                                                     experimental_long=True, docs=True)
   return CP
 
 

--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -2,7 +2,10 @@ import numpy as np
 from opendbc.car import Bus, get_safety_config, structs
 from opendbc.car.carlog import carlog
 from opendbc.car.common.conversions import Conversions as CV
+from opendbc.car.ford.carcontroller import CarController
+from opendbc.car.ford.carstate import CarState
 from opendbc.car.ford.fordcan import CanBus
+from opendbc.car.ford.radar_interface import RadarInterface
 from opendbc.car.ford.values import CarControllerParams, DBC, Ecu, FordFlags, RADAR, FordSafetyFlags
 from opendbc.car.interfaces import CarInterfaceBase
 
@@ -10,6 +13,10 @@ TransmissionType = structs.CarParams.TransmissionType
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+  RadarInterface = RadarInterface
+
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):
     # PCM doesn't allow acceleration near cruise_speed,

--- a/opendbc/car/gm/interface.py
+++ b/opendbc/car/gm/interface.py
@@ -5,7 +5,9 @@ from math import fabs, exp
 from opendbc.car import get_safety_config, get_friction, structs
 from opendbc.car.common.basedir import BASEDIR
 from opendbc.car.common.conversions import Conversions as CV
-from opendbc.car.gm.radar_interface import RADAR_HEADER_MSG
+from opendbc.car.gm.carcontroller import CarController
+from opendbc.car.gm.carstate import CarState
+from opendbc.car.gm.radar_interface import RadarInterface, RADAR_HEADER_MSG
 from opendbc.car.gm.values import CAR, CarControllerParams, EV_CAR, CAMERA_ACC_CAR, SDGM_CAR, ALT_ACCS, CanBus, GMSafetyFlags
 from opendbc.car.interfaces import CarInterfaceBase, TorqueFromLateralAccelCallbackType, FRICTION_THRESHOLD, LatControlInputs, NanoFFModel
 
@@ -22,6 +24,10 @@ NEURAL_PARAMS_PATH = os.path.join(BASEDIR, 'torque_data/neural_ff_weights.json')
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+  RadarInterface = RadarInterface
+
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):
     return CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX

--- a/opendbc/car/gm/radar_interface.py
+++ b/opendbc/car/gm/radar_interface.py
@@ -56,12 +56,10 @@ class RadarInterface(RadarInterfaceBase):
     fault = header['FLRRSnsrBlckd'] or header['FLRRSnstvFltPrsntInt'] or \
       header['FLRRYawRtPlsblityFlt'] or header['FLRRHWFltPrsntInt'] or \
       header['FLRRAntTngFltPrsnt'] or header['FLRRAlgnFltPrsnt']
-    errors = []
     if not self.rcp.can_valid:
-      errors.append("canError")
+      ret.errors.canError = True
     if fault:
-      errors.append("fault")
-    ret.errors = errors
+      ret.errors.radarFault = True
 
     currentTargets = set()
     num_targets = header['FLRRNumValidTargets']

--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -2,16 +2,23 @@
 import numpy as np
 from opendbc.car import get_safety_config, structs
 from opendbc.car.common.conversions import Conversions as CV
+from opendbc.car.disable_ecu import disable_ecu
 from opendbc.car.honda.hondacan import CanBus
 from opendbc.car.honda.values import CarControllerParams, HondaFlags, CAR, HONDA_BOSCH, \
                                                  HONDA_NIDEC_ALT_SCM_MESSAGES, HONDA_BOSCH_RADARLESS, HondaSafetyFlags
+from opendbc.car.honda.carcontroller import CarController
+from opendbc.car.honda.carstate import CarState
+from opendbc.car.honda.radar_interface import RadarInterface
 from opendbc.car.interfaces import CarInterfaceBase
-from opendbc.car.disable_ecu import disable_ecu
 
 TransmissionType = structs.CarParams.TransmissionType
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+  RadarInterface = RadarInterface
+
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):
     if CP.carFingerprint in HONDA_BOSCH:

--- a/opendbc/car/honda/radar_interface.py
+++ b/opendbc/car/honda/radar_interface.py
@@ -67,14 +67,12 @@ class RadarInterface(RadarInterfaceBase):
         if ii in self.pts:
           del self.pts[ii]
 
-    errors = []
     if not self.rcp.can_valid:
-      errors.append("canError")
+      ret.errors.canError = True
     if self.radar_fault:
-      errors.append("fault")
+      ret.errors.radarFault = True
     if self.radar_wrong_config:
-      errors.append("wrongConfig")
-    ret.errors = errors
+      ret.errors.wrongConfig = True
 
     ret.points = list(self.pts.values())
 

--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -6,6 +6,9 @@ from opendbc.car.hyundai.values import HyundaiFlags, CAR, DBC, \
 from opendbc.car.hyundai.radar_interface import RADAR_START_ADDR
 from opendbc.car.interfaces import CarInterfaceBase
 from opendbc.car.disable_ecu import disable_ecu
+from opendbc.car.hyundai.carcontroller import CarController
+from opendbc.car.hyundai.carstate import CarState
+from opendbc.car.hyundai.radar_interface import RadarInterface
 
 from opendbc.sunnypilot.car.hyundai.enable_radar_tracks import enable_radar_tracks
 from opendbc.sunnypilot.car.hyundai.escc import ESCC_MSG
@@ -19,6 +22,10 @@ ENABLE_BUTTONS = (ButtonType.accelCruise, ButtonType.decelCruise, ButtonType.can
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+  RadarInterface = RadarInterface
+
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:
     ret.brand = "hyundai"

--- a/opendbc/car/hyundai/radar_interface.py
+++ b/opendbc/car/hyundai/radar_interface.py
@@ -57,11 +57,8 @@ class RadarInterface(RadarInterfaceBase, EsccRadarInterfaceBase):
     if self.rcp is None:
       return ret
 
-    errors = []
-
     if not self.rcp.can_valid:
-      errors.append("canError")
-    ret.errors = errors
+      ret.errors.canError = True
 
     if self.use_escc:
       return self.update_escc(ret)

--- a/opendbc/car/mazda/interface.py
+++ b/opendbc/car/mazda/interface.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 from opendbc.car import get_safety_config, structs
 from opendbc.car.common.conversions import Conversions as CV
-from opendbc.car.mazda.values import CAR, LKAS_LIMITS
 from opendbc.car.interfaces import CarInterfaceBase
-
+from opendbc.car.mazda.carcontroller import CarController
+from opendbc.car.mazda.carstate import CarState
+from opendbc.car.mazda.values import CAR, LKAS_LIMITS
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/mazda/radar_interface.py
+++ b/opendbc/car/mazda/radar_interface.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python3
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/mock/interface.py
+++ b/opendbc/car/mock/interface.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 from opendbc.car import structs
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.mock.carcontroller import CarController
+from opendbc.car.mock.carstate import CarState
 
 
 # mocked car interface for dashcam mode
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/mock/radar_interface.py
+++ b/opendbc/car/mock/radar_interface.py
@@ -1,4 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/nissan/interface.py
+++ b/opendbc/car/nissan/interface.py
@@ -1,10 +1,14 @@
 from opendbc.car import get_safety_config, structs
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.nissan.carcontroller import CarController
+from opendbc.car.nissan.carstate import CarState
 from opendbc.car.nissan.values import CAR, NissanSafetyFlags
 from opendbc.sunnypilot.car.nissan.values import NissanSafetyFlagsSP
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/nissan/radar_interface.py
+++ b/opendbc/car/nissan/radar_interface.py
@@ -1,4 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/rivian/interface.py
+++ b/opendbc/car/rivian/interface.py
@@ -1,8 +1,14 @@
 from opendbc.car import get_safety_config, structs
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.rivian.carcontroller import CarController
+from opendbc.car.rivian.carstate import CarState
+from opendbc.car.rivian.radar_interface import RadarInterface
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+  RadarInterface = RadarInterface
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/rivian/radar_interface.py
+++ b/opendbc/car/rivian/radar_interface.py
@@ -43,11 +43,8 @@ class RadarInterface(RadarInterfaceBase):
     if self.rcp is None:
       return ret
 
-    errors = []
-
     if not self.rcp.can_valid:
-      errors.append("canError")
-    ret.errors = errors
+      ret.errors.canError = True
 
     for addr in range(RADAR_START_ADDR, RADAR_START_ADDR + RADAR_MSG_COUNT):
       msg = self.rcp.vl[f"RADAR_TRACK_{addr:x}"]

--- a/opendbc/car/subaru/interface.py
+++ b/opendbc/car/subaru/interface.py
@@ -1,10 +1,14 @@
 from opendbc.car import get_safety_config, structs
 from opendbc.car.disable_ecu import disable_ecu
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.subaru.carcontroller import CarController
+from opendbc.car.subaru.carstate import CarState
 from opendbc.car.subaru.values import CAR, GLOBAL_ES_ADDR, SubaruFlags, SubaruSafetyFlags
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate: CAR, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/subaru/radar_interface.py
+++ b/opendbc/car/subaru/radar_interface.py
@@ -1,4 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/tesla/interface.py
+++ b/opendbc/car/tesla/interface.py
@@ -1,9 +1,13 @@
 from opendbc.car import get_safety_config, structs
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.tesla.carcontroller import CarController
+from opendbc.car.tesla.carstate import CarState
 from opendbc.car.tesla.values import TeslaSafetyFlags
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/tesla/radar_interface.py
+++ b/opendbc/car/tesla/radar_interface.py
@@ -1,5 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/tests/test_car_interfaces.py
+++ b/opendbc/car/tests/test_car_interfaces.py
@@ -54,7 +54,7 @@ class TestCarInterfaces:
             phases=(Phase.reuse, Phase.generate, Phase.shrink))
   @given(data=st.data())
   def test_car_interfaces(self, car_name, data):
-    CarInterface, CarController, CarState, RadarInterface = interfaces[car_name]
+    CarInterface = interfaces[car_name]
 
     args = get_fuzzy_car_interface_args(data.draw)
 
@@ -62,7 +62,7 @@ class TestCarInterfaces:
                                          experimental_long=args['experimental_long'], docs=False)
     car_params_sp = CarInterface.get_params_sp(car_params, car_name, args['fingerprints'], args['car_fw'],
                                                            experimental_long=args['experimental_long'], docs=False)
-    car_interface = CarInterface(car_params, car_params_sp, CarController, CarState)
+    car_interface = CarInterface(car_params, car_params_sp)
     assert car_params
     assert car_params_sp
     assert car_interface
@@ -111,7 +111,7 @@ class TestCarInterfaces:
       now_nanos += DT_CTRL * 1e9  # 10ms
 
     # Test radar interface
-    radar_interface = RadarInterface(car_params, car_params_sp)
+    radar_interface = CarInterface.RadarInterface(car_params, car_params_sp)
     assert radar_interface
 
     # Run radar interface once

--- a/opendbc/car/tests/test_fw_fingerprint.py
+++ b/opendbc/car/tests/test_fw_fingerprint.py
@@ -126,7 +126,7 @@ class TestFwFingerprint:
     blacklisted_addrs = (0x7c4, 0x7d0)  # includes A/C ecu and an unknown ecu
     for car_model, ecus in FW_VERSIONS.items():
       with subtests.test(car_model=car_model.value):
-        CP = interfaces[car_model][0].get_non_essential_params(car_model)
+        CP = interfaces[car_model].get_non_essential_params(car_model)
         if CP.brand == 'subaru':
           for ecu in ecus.keys():
             assert ecu[1] not in blacklisted_addrs, f'{car_model}: Blacklisted ecu: (Ecu.{ecu[0]}, {hex(ecu[1])})'

--- a/opendbc/car/tests/test_lateral_limits.py
+++ b/opendbc/car/tests/test_lateral_limits.py
@@ -26,7 +26,7 @@ class TestLateralLimits:
 
   @classmethod
   def setup_class(cls):
-    CarInterface, _, _, _ = interfaces[cls.car_model]
+    CarInterface = interfaces[cls.car_model]
     CP = CarInterface.get_non_essential_params(cls.car_model)
 
     if cls.car_model == 'MOCK':

--- a/opendbc/car/toyota/interface.py
+++ b/opendbc/car/toyota/interface.py
@@ -1,4 +1,7 @@
 from opendbc.car import Bus, structs, get_safety_config, uds
+from opendbc.car.toyota.carstate import CarState
+from opendbc.car.toyota.carcontroller import CarController
+from opendbc.car.toyota.radar_interface import RadarInterface
 from opendbc.car.toyota.values import Ecu, CAR, DBC, ToyotaFlags, CarControllerParams, TSS2_CAR, RADAR_ACC_CAR, NO_DSU_CAR, \
                                                   MIN_ACC_SPEED, EPS_SCALE, UNSUPPORTED_DSU_CAR, NO_STOP_TIMER_CAR, ANGLE_CONTROL_CAR, \
                                                   ToyotaSafetyFlags
@@ -10,6 +13,10 @@ SteerControlType = structs.CarParams.SteerControlType
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+  RadarInterface = RadarInterface
+
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):
     return CarControllerParams(CP).ACCEL_MIN, CarControllerParams(CP).ACCEL_MAX

--- a/opendbc/car/toyota/radar_interface.py
+++ b/opendbc/car/toyota/radar_interface.py
@@ -55,10 +55,8 @@ class RadarInterface(RadarInterfaceBase):
 
   def _update(self, updated_messages):
     ret = RadarData()
-    errors = []
     if not self.rcp.can_valid:
-      errors.append("canError")
-    ret.errors = errors
+      ret.errors.canError = True
 
     for ii in sorted(updated_messages):
       if ii in self.RADAR_A_MSGS:

--- a/opendbc/car/volkswagen/interface.py
+++ b/opendbc/car/volkswagen/interface.py
@@ -1,9 +1,14 @@
 from opendbc.car import get_safety_config, structs
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.volkswagen.carcontroller import CarController
+from opendbc.car.volkswagen.carstate import CarState
 from opendbc.car.volkswagen.values import CAR, NetworkLocation, TransmissionType, VolkswagenFlags, VolkswagenSafetyFlags
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate: CAR, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:
     ret.brand = "volkswagen"

--- a/opendbc/car/volkswagen/radar_interface.py
+++ b/opendbc/car/volkswagen/radar_interface.py
@@ -1,4 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -285,7 +285,12 @@ static int get_fwd_bus(int bus_num) {
 }
 
 int safety_fwd_hook(int bus_num, int addr) {
-  const bool blocked = relay_malfunction || current_hooks->fwd(bus_num, addr);
+  bool blocked = relay_malfunction || current_safety_config.disable_forwarding;
+
+  if (!blocked && (current_hooks->fwd != NULL)) {
+    blocked = current_hooks->fwd(bus_num, addr);
+  }
+
   return blocked ? -1 : get_fwd_bus(bus_num);
 }
 
@@ -466,6 +471,7 @@ int set_safety_hooks(uint16_t mode, uint16_t param) {
   current_safety_config.rx_checks_len = 0;
   current_safety_config.tx_msgs = NULL;
   current_safety_config.tx_msgs_len = 0;
+  current_safety_config.disable_forwarding = false;
 
   int set_status = -1;  // not set
   int hook_config_count = sizeof(safety_hook_registry) / sizeof(safety_hook_config);
@@ -483,6 +489,7 @@ int set_safety_hooks(uint16_t mode, uint16_t param) {
     current_safety_config.rx_checks_len = cfg.rx_checks_len;
     current_safety_config.tx_msgs = cfg.tx_msgs;
     current_safety_config.tx_msgs_len = cfg.tx_msgs_len;
+    current_safety_config.disable_forwarding = cfg.disable_forwarding;
     // reset all dynamic fields in addr struct
     for (int j = 0; j < current_safety_config.rx_checks_len; j++) {
       current_safety_config.rx_checks[j].status = (RxStatus){0};

--- a/opendbc/safety/safety/safety_body.h
+++ b/opendbc/safety/safety/safety_body.h
@@ -39,12 +39,13 @@ static safety_config body_init(uint16_t param) {
                                         {0x1, 0, 8, false}}; // CAN flasher
 
   UNUSED(param);
-  return BUILD_SAFETY_CFG(body_rx_checks, BODY_TX_MSGS);
+  safety_config ret = BUILD_SAFETY_CFG(body_rx_checks, BODY_TX_MSGS);
+  ret.disable_forwarding = true;
+  return ret;
 }
 
 const safety_hooks body_hooks = {
   .init = body_init,
   .rx = body_rx_hook,
   .tx = body_tx_hook,
-  .fwd = default_fwd_hook,
 };

--- a/opendbc/safety/safety/safety_defaults.h
+++ b/opendbc/safety/safety/safety_defaults.h
@@ -13,7 +13,7 @@ void default_rx_hook(const CANPacket_t *to_push) {
 
 static safety_config nooutput_init(uint16_t param) {
   UNUSED(param);
-  return (safety_config){NULL, 0, NULL, 0};
+  return (safety_config){NULL, 0, NULL, 0, true};
 }
 
 // GCOV_EXCL_START
@@ -24,30 +24,19 @@ static bool nooutput_tx_hook(const CANPacket_t *to_send) {
 }
 // GCOV_EXCL_STOP
 
-static bool default_fwd_hook(int bus_num, int addr) {
-  UNUSED(bus_num);
-  UNUSED(addr);
-  return true;
-}
-
 const safety_hooks nooutput_hooks = {
   .init = nooutput_init,
   .rx = default_rx_hook,
   .tx = nooutput_tx_hook,
-  .fwd = default_fwd_hook,
 };
 
 // *** all output safety mode ***
-
-// Enables passthrough mode where relay is open and bus 0 gets forwarded to bus 2 and vice versa
-static bool alloutput_passthrough = false;
-
 static safety_config alloutput_init(uint16_t param) {
   // Enables passthrough mode where relay is open and bus 0 gets forwarded to bus 2 and vice versa
   const uint16_t ALLOUTPUT_PARAM_PASSTHROUGH = 1;
   controls_allowed = true;
-  alloutput_passthrough = GET_FLAG(param, ALLOUTPUT_PARAM_PASSTHROUGH);
-  return (safety_config){NULL, 0, NULL, 0};
+  bool alloutput_passthrough = GET_FLAG(param, ALLOUTPUT_PARAM_PASSTHROUGH);
+  return (safety_config){NULL, 0, NULL, 0, !alloutput_passthrough};
 }
 
 static bool alloutput_tx_hook(const CANPacket_t *to_send) {
@@ -55,15 +44,8 @@ static bool alloutput_tx_hook(const CANPacket_t *to_send) {
   return true;
 }
 
-static bool alloutput_fwd_hook(int bus_num, int addr) {
-  UNUSED(bus_num);
-  UNUSED(addr);
-  return !alloutput_passthrough;
-}
-
 const safety_hooks alloutput_hooks = {
   .init = alloutput_init,
   .rx = default_rx_hook,
   .tx = alloutput_tx_hook,
-  .fwd = alloutput_fwd_hook,
 };

--- a/opendbc/safety/safety/safety_elm327.h
+++ b/opendbc/safety/safety/safety_elm327.h
@@ -38,5 +38,4 @@ const safety_hooks elm327_hooks = {
   .init = nooutput_init,
   .rx = default_rx_hook,
   .tx = elm327_tx_hook,
-  .fwd = default_fwd_hook,
 };

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -8,17 +8,20 @@
 #define GET_FLAG(value, mask) (((__typeof__(mask))(value) & (mask)) == (mask)) // cppcheck-suppress misra-c2012-1.2; allow __typeof__
 
 #define BUILD_SAFETY_CFG(rx, tx) ((safety_config){(rx), (sizeof((rx)) / sizeof((rx)[0])), \
-                                                  (tx), (sizeof((tx)) / sizeof((tx)[0]))})
+                                                  (tx), (sizeof((tx)) / sizeof((tx)[0])), \
+                                                  false})
 #define SET_RX_CHECKS(rx, config) \
   do { \
     (config).rx_checks = (rx); \
     (config).rx_checks_len = sizeof((rx)) / sizeof((rx)[0]); \
+    (config).disable_forwarding = false; \
   } while (0);
 
 #define SET_TX_MSGS(tx, config) \
   do { \
     (config).tx_msgs = (tx); \
     (config).tx_msgs_len = sizeof((tx)) / sizeof((tx)[0]); \
+    (config).disable_forwarding = false; \
   } while(0);
 
 #define UPDATE_VEHICLE_SPEED(val_ms) (update_sample(&vehicle_speed, ROUND((val_ms) * VEHICLE_SPEED_FACTOR)))
@@ -152,6 +155,7 @@ typedef struct {
   int rx_checks_len;
   const CanMsg *tx_msgs;
   int tx_msgs_len;
+  bool disable_forwarding;
 } safety_config;
 
 typedef uint32_t (*get_checksum_t)(const CANPacket_t *to_push);


### PR DESCRIPTION
## Summary by Sourcery

Refactors the car interfaces to remove the need to pass `CarController`, `CarState`, and `RadarInterface` to the `CarInterface` constructor. The `CarInterface` now defines these classes as attributes. This change simplifies the car interface initialization and removes the need for the `get_car_interface` and `get_radar_interface` functions.

Enhancements:
- Refactor car interfaces to define `CarController`, `CarState`, and `RadarInterface` as attributes.
- Refactor radar interfaces to report errors using a struct instead of a list.