### PR TITLE
Hyundai: Radar interface extension

### DIFF
--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -168,6 +168,9 @@ class CarInterface(CarInterfaceBase):
     if stock_cp.flags & HyundaiFlags.HAS_LDA_BUTTON:
       ret.safetyParam |= HyundaiSafetyFlagsSP.HAS_LDA_BUTTON
 
+    if stock_cp.flags & (HyundaiFlags.CANFD_CAMERA_SCC | HyundaiFlags.CAMERA_SCC):
+      stock_cp.radarUnavailable = False
+
     return ret
 
   @staticmethod

--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -168,9 +168,6 @@ class CarInterface(CarInterfaceBase):
     if stock_cp.flags & HyundaiFlags.HAS_LDA_BUTTON:
       ret.safetyParam |= HyundaiSafetyFlagsSP.HAS_LDA_BUTTON
 
-    if stock_cp.flags & (HyundaiFlags.CANFD_CAMERA_SCC | HyundaiFlags.CAMERA_SCC):
-      stock_cp.radarUnavailable = False
-
     return ret
 
   @staticmethod

--- a/opendbc/car/hyundai/radar_interface.py
+++ b/opendbc/car/hyundai/radar_interface.py
@@ -32,7 +32,7 @@ class RadarInterface(RadarInterfaceBase, RadarInterfaceExt):
     self.rcp = get_radar_can_parser(CP)
 
     if self.rcp is None:
-      self.initialize_radar_ext()
+      self.initialize_radar_ext(self.trigger_msg)
 
   def update(self, can_strings):
     if self.radar_off_can or (self.rcp is None):

--- a/opendbc/car/hyundai/radar_interface.py
+++ b/opendbc/car/hyundai/radar_interface.py
@@ -32,7 +32,7 @@ class RadarInterface(RadarInterfaceBase, RadarInterfaceExt):
     self.rcp = get_radar_can_parser(CP)
 
     if self.rcp is None:
-      self.rcp, self.trigger_msg = self.initialize_radar_ext(self.trigger_msg)
+      self.initialize_radar_ext()
 
   def update(self, can_strings):
     if self.radar_off_can or (self.rcp is None):

--- a/opendbc/car/hyundai/radar_interface.py
+++ b/opendbc/car/hyundai/radar_interface.py
@@ -5,7 +5,7 @@ from opendbc.car import Bus, structs
 from opendbc.car.interfaces import RadarInterfaceBase
 from opendbc.car.hyundai.values import DBC
 
-from opendbc.sunnypilot.car.hyundai.escc import EsccRadarInterfaceBase
+from opendbc.sunnypilot.car.hyundai.radar_interface_ext import RadarInterfaceExt
 
 RADAR_START_ADDR = 0x500
 RADAR_MSG_COUNT = 32
@@ -20,10 +20,10 @@ def get_radar_can_parser(CP):
   return CANParser(DBC[CP.carFingerprint][Bus.radar], messages, 1)
 
 
-class RadarInterface(RadarInterfaceBase, EsccRadarInterfaceBase):
+class RadarInterface(RadarInterfaceBase, RadarInterfaceExt):
   def __init__(self, CP, CP_SP):
     RadarInterfaceBase.__init__(self, CP, CP_SP)
-    EsccRadarInterfaceBase.__init__(self, CP, CP_SP)
+    RadarInterfaceExt.__init__(self, CP, CP_SP)
     self.updated_messages = set()
     self.trigger_msg = RADAR_START_ADDR + RADAR_MSG_COUNT - 1
     self.track_id = 0
@@ -31,11 +31,8 @@ class RadarInterface(RadarInterfaceBase, EsccRadarInterfaceBase):
     self.radar_off_can = CP.radarUnavailable
     self.rcp = get_radar_can_parser(CP)
 
-    # If radar tracks are not available and ESCC is enabled, override radar parser with the ESCC parser and trigger message
-    if self.rcp is None and self.ESCC.enabled:
-      self.rcp = self.ESCC.get_radar_can_parser()
-      self.trigger_msg = self.ESCC.trigger_msg
-      self.use_escc = True
+    if self.rcp is None:
+      self.rcp, self.trigger_msg = self.initialize_radar_ext(self.trigger_msg)
 
   def update(self, can_strings):
     if self.radar_off_can or (self.rcp is None):
@@ -60,8 +57,8 @@ class RadarInterface(RadarInterfaceBase, EsccRadarInterfaceBase):
     if not self.rcp.can_valid:
       ret.errors.canError = True
 
-    if self.use_escc:
-      return self.update_escc(ret)
+    if self.use_radar_interface_ext():
+      return self.update_ext(ret)
 
     for addr in range(RADAR_START_ADDR, RADAR_START_ADDR + RADAR_MSG_COUNT):
       msg = self.rcp.vl[f"RADAR_TRACK_{addr:x}"]

--- a/opendbc/car/hyundai/radar_interface.py
+++ b/opendbc/car/hyundai/radar_interface.py
@@ -57,7 +57,7 @@ class RadarInterface(RadarInterfaceBase, RadarInterfaceExt):
     if not self.rcp.can_valid:
       ret.errors.canError = True
 
-    if self.use_radar_interface_ext():
+    if self.use_radar_interface_ext:
       return self.update_ext(ret)
 
     for addr in range(RADAR_START_ADDR, RADAR_START_ADDR + RADAR_MSG_COUNT):

--- a/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
+++ b/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
@@ -7,6 +7,7 @@ from opendbc.sunnypilot.car.hyundai.escc import EsccRadarInterfaceBase
 
 class RadarInterfaceExt(EsccRadarInterfaceBase):
   msg_src: str
+  trigger_msg: int
   rcp: CANParser
   pts: dict[int, structs.RadarData.RadarPoint]
 
@@ -17,13 +18,13 @@ class RadarInterfaceExt(EsccRadarInterfaceBase):
 
     self.track_id = 0
 
-  def initialize_radar_ext(self, trigger_msg) -> tuple[CANParser, int]:
-    if self.ESCC.enabled:
-      self.use_escc = True
+  @property
+  def use_radar_interface_ext(self) -> bool:
+    return self.use_escc
 
-    rcp = self.get_radar_ext_can_parser()
-    trigger_msg = self.get_trigger_msg() or trigger_msg
-    return rcp, trigger_msg
+  def get_msg_src(self) -> str | None:
+    if self.use_escc:
+      return "ESCC"
 
   def get_radar_ext_can_parser(self) -> CANParser:
     if self.ESCC.enabled:
@@ -38,13 +39,12 @@ class RadarInterfaceExt(EsccRadarInterfaceBase):
     if self.ESCC.enabled:
       return self.ESCC.trigger_msg
 
-  def get_msg_src(self) -> str | None:
-    if self.use_escc:
-      return "ESCC"
+  def initialize_radar_ext(self) -> None:
+    if self.ESCC.enabled:
+      self.use_escc = True
 
-  @property
-  def use_radar_interface_ext(self) -> bool:
-    return self.use_escc
+    self.rcp = self.get_radar_ext_can_parser()
+    self.trigger_msg = self.get_trigger_msg()
 
   def update_ext(self, ret: structs.RadarData) -> structs.RadarData:
     for ii in range(1):

--- a/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
+++ b/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
@@ -17,14 +17,14 @@ class RadarInterfaceExt(EsccRadarInterfaceBase):
 
     self.track_id = 0
 
-  def initialize_radar_ext(self, trigger_msg):
+  def initialize_radar_ext(self, trigger_msg) -> tuple[CANParser, int | None]:
     if self.ESCC.enabled:
       self.use_escc = True
 
     rcp, trigger_msg = self.get_radar_ext_can_parser(trigger_msg)
     return rcp, trigger_msg
 
-  def get_radar_ext_can_parser(self, trigger_msg):
+  def get_radar_ext_can_parser(self, trigger_msg) -> tuple[CANParser, int | None]:
     if self.ESCC.enabled:
       trigger_msg = self.ESCC.trigger_msg
       lead_src, bus = "ESCC", 0
@@ -33,14 +33,14 @@ class RadarInterfaceExt(EsccRadarInterfaceBase):
     messages = [(lead_src, 50)]
     return CANParser(DBC[self.CP.carFingerprint][Bus.pt], messages, bus), trigger_msg
 
-  def get_msg_src(self):
+  def get_msg_src(self) -> str | None:
     if self.use_escc:
       return "ESCC"
 
   def use_radar_interface_ext(self) -> bool:
     return self.use_escc
 
-  def update_ext(self, ret):
+  def update_ext(self, ret: structs.RadarData) -> structs.RadarData:
     for ii in range(1):
       msg_src = self.get_msg_src()
       msg = self.rcp.vl[msg_src]

--- a/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
+++ b/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
@@ -16,22 +16,25 @@ class RadarInterfaceExt(EsccRadarInterfaceBase):
     self.CP_SP = CP_SP
 
     self.track_id = 0
+    self.use_escc = self.ESCC.enabled
 
-  def initialize_radar_ext(self, trigger_msg) -> tuple[CANParser, int | None]:
-    if self.ESCC.enabled:
-      self.use_escc = True
-
-    rcp, trigger_msg = self.get_radar_ext_can_parser(trigger_msg)
+  def initialize_radar_ext(self, trigger_msg) -> tuple[CANParser, int]:
+    rcp = self.get_radar_ext_can_parser()
+    trigger_msg = self.get_trigger_msg() or trigger_msg
     return rcp, trigger_msg
 
-  def get_radar_ext_can_parser(self, trigger_msg) -> tuple[CANParser, int | None]:
+  def get_radar_ext_can_parser(self) -> CANParser:
     if self.ESCC.enabled:
-      trigger_msg = self.ESCC.trigger_msg
       lead_src, bus = "ESCC", 0
     else:
-      return None, trigger_msg
+      return None
+
     messages = [(lead_src, 50)]
-    return CANParser(DBC[self.CP.carFingerprint][Bus.pt], messages, bus), trigger_msg
+    return CANParser(DBC[self.CP.carFingerprint][Bus.pt], messages, bus)
+
+  def get_trigger_msg(self) -> int | None:
+    if self.ESCC.enabled:
+      return self.ESCC.trigger_msg
 
   def get_msg_src(self) -> str | None:
     if self.use_escc:

--- a/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
+++ b/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
@@ -35,16 +35,17 @@ class RadarInterfaceExt(EsccRadarInterfaceBase):
     messages = [(lead_src, 50)]
     return CANParser(DBC[self.CP.carFingerprint][Bus.pt], messages, bus)
 
-  def get_trigger_msg(self) -> int | None:
+  def get_trigger_msg(self, default_trigger_msg) -> int:
     if self.ESCC.enabled:
       return self.ESCC.trigger_msg
+    return default_trigger_msg
 
-  def initialize_radar_ext(self) -> None:
+  def initialize_radar_ext(self, default_trigger_msg) -> None:
     if self.ESCC.enabled:
       self.use_escc = True
 
     self.rcp = self.get_radar_ext_can_parser()
-    self.trigger_msg = self.get_trigger_msg()
+    self.trigger_msg = self.get_trigger_msg(default_trigger_msg)
 
   def update_ext(self, ret: structs.RadarData) -> structs.RadarData:
     for ii in range(1):

--- a/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
+++ b/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
@@ -1,0 +1,74 @@
+from opendbc.can.parser import CANParser
+from opendbc.car import structs, Bus
+from opendbc.car.hyundai.values import DBC
+
+from opendbc.car.hyundai.hyundaicanfd import CanBus
+from opendbc.car.hyundai.values import HyundaiFlags
+from opendbc.sunnypilot.car.hyundai.escc import EsccRadarInterfaceBase
+
+
+class RadarInterfaceExt(EsccRadarInterfaceBase):
+  msg_src: str
+  rcp: CANParser
+  pts: dict[int, structs.RadarData.RadarPoint]
+
+  def __init__(self, CP: structs.CarParams, CP_SP: structs.CarParamsSP):
+    EsccRadarInterfaceBase.__init__(self, CP, CP_SP)
+    self.CP = CP
+    self.CP_SP = CP_SP
+
+    self.track_id = 0
+
+  def initialize_radar_ext(self, trigger_msg):
+    if self.ESCC.enabled:
+      self.use_escc = True
+
+    rcp, trigger_msg = self.get_radar_ext_can_parser(trigger_msg)
+    return rcp, trigger_msg
+
+  def get_radar_ext_can_parser(self, trigger_msg):
+    if self.ESCC.enabled:
+      trigger_msg = self.ESCC.trigger_msg
+      lead_src, bus = "ESCC", 0
+    elif self.CP.flags & (HyundaiFlags.CAMERA_SCC | HyundaiFlags.CANFD_CAMERA_SCC):
+      trigger_msg = 0x1A0 if self.CP.flags & HyundaiFlags.CANFD_CAMERA_SCC else 0x420
+      lead_src = "SCC_CONTROL" if self.CP.flags & HyundaiFlags.CANFD_CAMERA_SCC else "SCC11"
+      bus = CanBus(self.CP).CAM if self.CP.flags & HyundaiFlags.CANFD_CAMERA_SCC else 2
+    else:
+      return None, trigger_msg
+    messages = [(lead_src, 50)]
+    return CANParser(DBC[self.CP.carFingerprint][Bus.pt], messages, bus), trigger_msg
+
+  def get_msg_src(self):
+    if self.use_escc:
+      return "ESCC"
+    if self.CP.flags & (HyundaiFlags.CAMERA_SCC | HyundaiFlags.CANFD_CAMERA_SCC):
+      return "SCC_CONTROL" if self.CP.flags & HyundaiFlags.CANFD_CAMERA_SCC else "SCC11"
+
+  def use_radar_interface_ext(self) -> bool:
+    return self.use_escc or self.CP.flags & (HyundaiFlags.CAMERA_SCC | HyundaiFlags.CANFD_CAMERA_SCC)
+
+  def update_ext(self, ret):
+    for ii in range(1):
+      msg_src = self.get_msg_src()
+      msg = self.rcp.vl[msg_src]
+
+      if ii not in self.pts:
+        self.pts[ii] = structs.RadarData.RadarPoint()
+        self.pts[ii].trackId = self.track_id
+        self.track_id += 1
+
+      valid = msg['ACC_ObjDist'] < 204.6 if self.CP.flags & HyundaiFlags.CANFD_CAMERA_SCC else msg['ACC_ObjStatus']
+      if valid:
+        self.pts[ii].measured = True
+        self.pts[ii].dRel = msg['ACC_ObjDist']
+        self.pts[ii].yRel = float('nan')  # FIXME-SP: Only some cars have lateral position from SCC
+        self.pts[ii].vRel = msg['ACC_ObjRelSpd']
+        self.pts[ii].aRel = float('nan')  # TODO-SP: calculate from ACC_ObjRelSpd and with timestep 50Hz (needs to modify in interfaces.py)
+        self.pts[ii].yvRel = float('nan')
+
+      else:
+        del self.pts[ii]
+
+    ret.points = list(self.pts.values())
+    return ret

--- a/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
+++ b/opendbc/sunnypilot/car/hyundai/radar_interface_ext.py
@@ -16,9 +16,11 @@ class RadarInterfaceExt(EsccRadarInterfaceBase):
     self.CP_SP = CP_SP
 
     self.track_id = 0
-    self.use_escc = self.ESCC.enabled
 
   def initialize_radar_ext(self, trigger_msg) -> tuple[CANParser, int]:
+    if self.ESCC.enabled:
+      self.use_escc = True
+
     rcp = self.get_radar_ext_can_parser()
     trigger_msg = self.get_trigger_msg() or trigger_msg
     return rcp, trigger_msg
@@ -40,6 +42,7 @@ class RadarInterfaceExt(EsccRadarInterfaceBase):
     if self.use_escc:
       return "ESCC"
 
+  @property
   def use_radar_interface_ext(self) -> bool:
     return self.use_escc
 

--- a/opendbc/sunnypilot/car/hyundai/tests/test_escc_base.py
+++ b/opendbc/sunnypilot/car/hyundai/tests/test_escc_base.py
@@ -59,8 +59,3 @@ class TestEscc:
     assert scc12_message["CF_VSM_DecCmdAct"] == 1
     assert scc12_message["CR_VSM_DecCmd"] == 1
     assert scc12_message["AEB_Status"] == 2
-
-  def test_get_radar_escc_parser(self, escc):
-    parser = escc.get_radar_can_parser()
-    assert parser is not None
-    assert parser.dbc_name == b"hyundai_kia_generic"


### PR DESCRIPTION
## Summary by Sourcery

Refactor and extend the Hyundai radar interface to improve flexibility and support for Enhanced Smart Cruise Control (ESCC) radar tracking

New Features:
- Introduce a new RadarInterfaceExt class to handle extended radar interface functionality
- Add support for fallback radar parsing when primary radar is unavailable

Enhancements:
- Modularize the radar interface extension logic into a separate class for better separation of concerns
- Add more flexible radar initialization and tracking for Hyundai vehicles

Chores:
- Remove direct ESCC radar parsing from the main radar interface
- Reorganize radar interface code to improve maintainability