### PR TITLE
Toyota: Update UI command to use `latActive`

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -266,7 +266,7 @@ class CarController(CarControllerBase):
       if self.frame % 20 == 0 or send_ui:
         can_sends.append(toyotacan.create_ui_command(self.packer, steer_alert, pcm_cancel_cmd, hud_control.leftLaneVisible,
                                                      hud_control.rightLaneVisible, hud_control.leftLaneDepart,
-                                                     hud_control.rightLaneDepart, CC.enabled, CS.lkas_hud))
+                                                     hud_control.rightLaneDepart, CC.latActive, CS.lkas_hud))
 
       if (self.frame % 100 == 0 or send_ui) and (self.CP.enableDsu or self.CP.flags & ToyotaFlags.DISABLE_RADAR.value):
         can_sends.append(toyotacan.create_fcw_command(self.packer, fcw_alert))


### PR DESCRIPTION
Replaced `CC.enabled` with `CC.latActive` in the UI command to better reflect lateral control state. This improves clarity and ensures proper signaling of active lateral features, such as the blue border on the driver's cluster or HUD when steering is engaged.

## Summary by Sourcery

Enhancements:
- Replace generic enabled flag with more specific lateral active state in UI command signaling