### PR TITLE
Hyundai Longitudinal: Another one

### DIFF
--- a/opendbc/sunnypilot/car/hyundai/carstate_ext.py
+++ b/opendbc/sunnypilot/car/hyundai/carstate_ext.py
@@ -14,8 +14,11 @@ from opendbc.can.parser import CANParser
 class CarStateExt:
   def __init__(self):
     super().__init__()
+    self.aBasis = 0.0
 
   def update(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser]) -> None:
     cp = can_parsers[Bus.pt]
 
     ret.brakeLightsDEPRECATED = bool(cp.vl["TCS13"]["BrakeLight"])
+
+    self.aBasis = cp.vl["TCS13"]["aBasis"]

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
@@ -59,5 +59,5 @@ class LongitudinalController:
     long_control_state = actuators.longControlState
 
     self.get_stopping_state(long_control_state)
-    self.calculate_a_value(CC)
     self.calculate_jerk(CC, CS, long_control_state)
+    self.calculate_a_value(CC)


### PR DESCRIPTION
## Summary by Sourcery

Modify Hyundai longitudinal control logic to improve acceleration and jerk calculation, introducing a new ego acceleration filter and adjusting the jerk calculation method

New Features:
- Add aBasis parameter to CarStateExt to capture additional acceleration information

Enhancements:
- Introduce a new ego acceleration filter (aego) with a different time constant
- Modify jerk calculation to use blended ego acceleration and future projection
- Adjust the order of method calls in the longitudinal controller to improve calculation sequence