### PR TITLE
Hyundai Longitudinal: aEgo blended round 3

### DIFF
--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -301,6 +301,8 @@ class CarState(CarStateBase, EsccCarStateBase, MadsCarState, CarStateExt):
     if self.CP.openpilotLongitudinalControl:
       ret.cruiseState.available = self.get_main_cruise(ret)
 
+    CarStateExt.update_canfd_ext(self, ret, can_parsers)
+
     return ret
 
   def get_can_parsers_canfd(self, CP):

--- a/opendbc/sunnypilot/car/hyundai/carstate_ext.py
+++ b/opendbc/sunnypilot/car/hyundai/carstate_ext.py
@@ -15,7 +15,16 @@ class CarStateExt:
   def __init__(self):
     super().__init__()
 
+    self.aBasis = 0.0
+
   def update(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser]) -> None:
     cp = can_parsers[Bus.pt]
 
     ret.brakeLightsDEPRECATED = bool(cp.vl["TCS13"]["BrakeLight"])
+
+    self.aBasis = cp.vl["TCS13"]["aBasis"]
+
+  def update_canfd_ext(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser]) -> None:
+    cp = can_parsers[Bus.pt]
+
+    self.aBasis = cp.vl["TCS"]["aBasis"]

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
@@ -157,14 +157,14 @@ class LongitudinalTuningController:
 
     accel_error = self.accel_cmd - self.state.accel_last
 
-    if self.accel_cmd > 0.005 and accel_error > 0.005:
+    if accel_error > 0.005:
       upper_jerk = float(np.interp(accel_error, UPPER_JERK_BP, UPPER_JERK_V))
     else:
       upper_jerk = 0.5
 
     if self.CP.radarUnavailable:
       lower_jerk = 5.0
-    elif self.accel_cmd < 0.005 and accel_error < 0.005:
+    elif self.accel_cmd < -0.005 or accel_error < -0.005:
       lower_jerk = float(np.interp(accel_error, LOWER_JERK_BP, LOWER_JERK_V))
     else:
       lower_jerk = 0.5

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
@@ -142,9 +142,9 @@ class LongitudinalTuningController:
 
       error_future = self.aego_blended_accel - a_ego_blended
       self.aego_blended_accel = self.pid.update(error_future,
-                                      speed=CS.out.vEgo,
-                                      feedforward=self.aego_blended_accel,
-                                      freeze_integrator=long_control_state != LongCtrlState.pid)
+                                                speed=CS.out.vEgo,
+                                                feedforward=self.aego_blended_accel,
+                                                freeze_integrator=long_control_state != LongCtrlState.pid)
     else:
       self.pid.reset()
 

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
@@ -25,8 +25,8 @@ JERK_THRESHOLD = 0.1
 UPPER_JERK_BP = [0.005,  0.03,  0.1,   0.25,  0.4,  0.6]
 UPPER_JERK_V  = [  0.5,   0.6,  1.0,    1.6,  2.0,  2.5]
 
-LOWER_JERK_BP = [-1.5, -1.0, -0.5, -0.25, -0.1, -0.025, -0.01, -0.005]
-LOWER_JERK_V  = [  3.3, 2.5,  1.9,  1.7,   1.5,  1.25,   1.0,   0.5]
+LOWER_JERK_BP = [-2.0, -1.5, -1.0, -0.25, -0.1, -0.025, -0.01, -0.005]
+LOWER_JERK_V  = [ 3.3,  2.4,  1.9,   1.7,  1.5,   1.25,   1.0,    0.5]
 
 
 def jerk_limited_integrator(desired_accel, last_accel, jerk_upper, jerk_lower) -> float:

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
@@ -17,7 +17,6 @@ from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 
 LongCtrlState = structs.CarControl.Actuators.LongControlState
 
-ACCEL_PID_UNWIND = 0.02 * DT_CTRL * 2
 JERK_STEP = 0.1
 JERK_THRESHOLD = 0.1
 

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
@@ -20,8 +20,11 @@ LongCtrlState = structs.CarControl.Actuators.LongControlState
 JERK_STEP = 0.1
 JERK_THRESHOLD = 0.1
 
-UPPER_JERK_BP = [0.005,  0.03,  0.1,   0.25,  0.4,  0.6]
-UPPER_JERK_V  = [  0.5,   0.6,  1.0,    1.6,  2.0,  2.5]
+UPPER_START_JERK_BP = [0.005,  0.6,  1.0,  1.6,  2.0]
+UPPER_START_JERK_V  = [  0.5,   0.6,  1.0,    1.6,  2.0]
+
+UPPER_JERK_BP = [0.005, 0.03, 0.5, 1.0,  1.5, 2.0]
+UPPER_JERK_V  = [  0.5,  0.6, 1.0, 1.5, 1.25, 2.0]
 
 LOWER_JERK_BP = [-2.0, -1.5, -1.0, -0.25, -0.1, -0.025, -0.01, -0.005]
 LOWER_JERK_V  = [ 3.3,  2.4,  1.9,   1.7,  1.5,   1.25,   1.0,    0.5]
@@ -141,13 +144,15 @@ class LongitudinalTuningController:
       upper_speed_factor = float(np.interp(velocity, [0.0, 5.0, 20.0], [1.0, 2.2, 1.0]))
 
     if accel_error > 0.005:
-      upper_jerk = float(np.interp(accel_error, UPPER_JERK_BP, UPPER_JERK_V))
+      _upper_bp = UPPER_START_JERK_BP if velocity < 5.0 else UPPER_JERK_BP
+      _upper_v = UPPER_START_JERK_V if velocity < 5.0 else UPPER_JERK_V
+      upper_jerk = float(np.interp(accel_error, _upper_bp, _upper_v))
     else:
       upper_jerk = 0.5
 
     if self.CP.radarUnavailable:
       lower_jerk = 5.0
-    elif self.accel_cmd < -0.005 or accel_error < -0.005:
+    elif accel_error < -0.005:
       lower_jerk = float(np.interp(accel_error, LOWER_JERK_BP, LOWER_JERK_V))
     else:
       lower_jerk = 0.5


### PR DESCRIPTION
## Summary by Sourcery

Enhance Hyundai longitudinal control by implementing an advanced ego-based acceleration blending strategy with PID control and jerk limiting

New Features:
- Introduce ego-based acceleration blending mechanism that considers vehicle speed, current acceleration, and future acceleration prediction

Enhancements:
- Implement a more sophisticated jerk limiting approach with dynamic upper and lower jerk thresholds
- Add PID controller with adaptive integration and unwind mechanism
- Improve acceleration control by blending ego and planned acceleration

Chores:
- Update CarState and CarStateExt classes to support new acceleration basis tracking