### PR TITLE
Hyundai Longitudinal: Lookahead jerk limits

### DIFF
--- a/opendbc/sunnypilot/car/hyundai/longitudinal/longitudinal_config.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/longitudinal_config.py
@@ -15,9 +15,9 @@ class CarTuningConfig:
   v_ego_stopping: float = 0.25
   v_ego_starting: float = 0.10
   stopping_decel_rate: float = 0.25
-  jerk_limits: tuple[float, float] = 0.25, 0.1
+  lookahead: tuple[float, float, float] = 0.25, 0.1, 0.5  # (upper min, lower min , lower max)
   longitudinal_actuator_delay: float = 0.45
-  lower_jerk_multiplier: float = 1.0
+  jerk_limits: float = 3.3
 
 
 # Default configurations for different car types
@@ -27,7 +27,6 @@ TUNING_CONFIGS = {
     stopping_decel_rate=0.275,
   ),
   "EV": CarTuningConfig(
-    jerk_limits=(0.25, 0.1),
     longitudinal_actuator_delay=0.45,
   ),
   "HYBRID": CarTuningConfig(
@@ -41,17 +40,20 @@ TUNING_CONFIGS = {
 CAR_SPECIFIC_CONFIGS = {
   CAR.HYUNDAI_ELANTRA_2021: CarTuningConfig(
     stopping_decel_rate=0.8,
+    lookahead=(0.25, 0.25, 0.5)
   ),
   CAR.KIA_NIRO_EV: CarTuningConfig(
     v_ego_stopping=0.1,
     stopping_decel_rate=0.1,
-    jerk_limits=(0.25, 0.2),
+    lookahead=(0.25, 0.3, 0.6),
+    jerk_limits=2.7,
     longitudinal_actuator_delay=0.45,
   ),
   CAR.HYUNDAI_IONIQ:CarTuningConfig(
     v_ego_stopping=0.25,
     stopping_decel_rate=0.4,
-    jerk_limits=(0.25, 0.1),
+    lookahead=(0.25, 0.1, 0.5),
+    jerk_limits=4.5,
     longitudinal_actuator_delay=0.45,
   )
 }

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/longitudinal_config.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/longitudinal_config.py
@@ -15,7 +15,7 @@ class CarTuningConfig:
   v_ego_stopping: float = 0.25
   v_ego_starting: float = 0.10
   stopping_decel_rate: float = 0.25
-  jerk_limits: tuple[float, float, float] = 2.5, 3.3, 2.5  # (min jerk, max lower jerk, max upper jerk)
+  jerk_limits: tuple[float, float] = 0.25, 0.1
   longitudinal_actuator_delay: float = 0.45
   lower_jerk_multiplier: float = 1.0
 
@@ -27,7 +27,7 @@ TUNING_CONFIGS = {
     stopping_decel_rate=0.275,
   ),
   "EV": CarTuningConfig(
-    jerk_limits=(2.50, 3.5, 3.0),
+    jerk_limits=(0.25, 0.1),
     longitudinal_actuator_delay=0.45,
   ),
   "HYBRID": CarTuningConfig(
@@ -45,13 +45,13 @@ CAR_SPECIFIC_CONFIGS = {
   CAR.KIA_NIRO_EV: CarTuningConfig(
     v_ego_stopping=0.1,
     stopping_decel_rate=0.1,
-    jerk_limits=(1.0, 2.7, 1.2),
+    jerk_limits=(0.25, 0.2),
     longitudinal_actuator_delay=0.45,
   ),
   CAR.HYUNDAI_IONIQ:CarTuningConfig(
     v_ego_stopping=0.25,
     stopping_decel_rate=0.4,
-    jerk_limits=(1.0, 4.5, 2.2),
+    jerk_limits=(0.25, 0.1),
     longitudinal_actuator_delay=0.45,
   )
 }

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
@@ -22,6 +22,8 @@ JERK_STEP = 0.1
 JERK_THRESHOLD = 0.1
 MIN_JERK = 0.5
 
+JERK_LOOKAHEAD_BP = [2., 5.]
+
 UPPER_JERK_LOOKAHEAD_V = [0.25, 0.5]
 LOWER_JERK_LOOKAHEAD_V = [0.1, 0.5]
 
@@ -129,8 +131,8 @@ class LongitudinalTuningController:
     accel_error = self.accel_cmd - self.aego.x
 
     # Lookahead jerk: How much jerk is needed to reach desired accel in future_t seconds
-    future_t_upper = float(np.interp(velocity, [2., 5.], UPPER_JERK_LOOKAHEAD_V))
-    future_t_lower = float(np.interp(velocity, [2., 5.], LOWER_JERK_LOOKAHEAD_V))
+    future_t_upper = float(np.interp(velocity, JERK_LOOKAHEAD_BP, UPPER_JERK_LOOKAHEAD_V))
+    future_t_lower = float(np.interp(velocity, JERK_LOOKAHEAD_BP, LOWER_JERK_LOOKAHEAD_V))
 
     # Required jerk to reach target accel in lookahead window
     j_ego_upper = accel_error / future_t_upper

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
@@ -22,7 +22,7 @@ JERK_STEP = 0.1
 JERK_THRESHOLD = 0.1
 MIN_JERK = 0.5
 
-JERK_LOOKAHEAD_BP = [2., 5.]
+JERK_LOOKAHEAD_BP = [2.0, 5.0]
 
 UPPER_JERK_LOOKAHEAD_V = [0.25, 0.5]
 LOWER_JERK_LOOKAHEAD_V = [0.1, 0.5]
@@ -131,8 +131,10 @@ class LongitudinalTuningController:
     accel_error = self.accel_cmd - self.aego.x
 
     # Lookahead jerk: How much jerk is needed to reach desired accel in future_t seconds
-    future_t_upper = float(np.interp(velocity, JERK_LOOKAHEAD_BP, UPPER_JERK_LOOKAHEAD_V))
-    future_t_lower = float(np.interp(velocity, JERK_LOOKAHEAD_BP, LOWER_JERK_LOOKAHEAD_V))
+    future_t_upper = float(np.interp(velocity, JERK_LOOKAHEAD_BP,
+                      [self.car_config.jerk_limits[0], UPPER_JERK_LOOKAHEAD_V[1]]))
+    future_t_lower = float(np.interp(velocity, JERK_LOOKAHEAD_BP,
+                      [self.car_config.jerk_limits[1], LOWER_JERK_LOOKAHEAD_V[1]]))
 
     # Required jerk to reach target accel in lookahead window
     j_ego_upper = accel_error / future_t_upper
@@ -144,10 +146,9 @@ class LongitudinalTuningController:
       upper_speed_factor = float(np.interp(velocity, [0.0, 5.0, 20.0], [2.0, 3.0, 1.0]))
     lower_speed_factor = float(np.interp(velocity, [0.0, 5.0, 20.0], [5.0, 5.0, 2.5]))
 
+    lower_jerk = max(-j_ego_lower, MIN_JERK)
     if self.CP.radarUnavailable:
       lower_jerk = 5.0
-    else:
-      lower_jerk = max(-j_ego_lower, MIN_JERK)
 
     # Final jerk limits with thresholds
     desired_jerk_upper = min(max(j_ego_upper, MIN_JERK), upper_speed_factor)

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
@@ -133,8 +133,8 @@ class LongitudinalTuningController:
     self.aego.update(a_ego_blended)
     j_ego = (self.aego.x - prev_aego) / (DT_CTRL * 2)
 
-    future_t = float(np.interp(CS.out.vEgo, [2., 5.], [0.1, 0.2]))
-    a_ego_blended_ = a_ego_blended + j_ego * future_t   # noqa: F841
+    future_t = float(np.interp(CS.out.vEgo, [2., 5.], [0.25, 0.5]))
+    a_ego_blended_ = a_ego_blended + j_ego * future_t
 
     accel_error_ = self.accel_cmd - a_ego_blended   # noqa: F841
     accel_error = a_ego_blended - self.state.accel_last

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/tuning_controller.py
@@ -136,8 +136,8 @@ class LongitudinalTuningController:
     future_t = float(np.interp(CS.out.vEgo, [2., 5.], [0.25, 0.5]))
     a_ego_blended_ = a_ego_blended + j_ego * future_t
 
-    accel_error_ = self.accel_cmd - a_ego_blended   # noqa: F841
-    accel_error = a_ego_blended - self.state.accel_last
+    accel_error_ = self.accel_cmd - a_ego_blended_
+    accel_error = a_ego_blended - self.state.accel_last  # noqa: F841
 
   # Jerk is limited by the following conditions imposed by ISO 15622:2018.
     velocity = CS.out.vEgo
@@ -146,11 +146,11 @@ class LongitudinalTuningController:
     if long_control_state == LongCtrlState.pid:
       upper_speed_factor = float(np.interp(velocity, [0.0, 5.0, 20.0], [2.0, 3.0, 1.0]))
 
-    if accel_error > 0.005:
+    if accel_error_ > 0.005:
       bp = UPPER_START_JERK_BP if velocity < 5.0 else UPPER_JERK_BP
       _upper_v = np.array(UPPER_START_JERK_V) if velocity < 5.0 else np.array(UPPER_JERK_V)
       _scaled_v = _upper_v * (self.car_config.jerk_limits[2] / _upper_v[-1])
-      upper_jerk = float(np.interp(accel_error, bp, _scaled_v))
+      upper_jerk = float(np.interp(accel_error_, bp, _scaled_v))
     else:
       upper_jerk = 0.5
 
@@ -161,8 +161,8 @@ class LongitudinalTuningController:
 
     if self.CP.radarUnavailable:
       lower_jerk = 5.0
-    elif accel_error < -0.005:
-      lower_jerk = float(np.interp(accel_error, LOWER_JERK_BP, dynamic_lower))
+    elif accel_error_ < -0.005:
+      lower_jerk = float(np.interp(accel_error_, LOWER_JERK_BP, dynamic_lower))
     else:
       lower_jerk = 0.5
 


### PR DESCRIPTION
## Summary by Sourcery

Modify jerk limit calculation for Hyundai longitudinal control to use a lookahead-based approach for determining upper and lower jerk limits

New Features:
- Introduce a lookahead jerk calculation that considers the time needed to reach the desired acceleration

Enhancements:
- Implement a more dynamic jerk limit calculation based on the future acceleration error using a time-based lookahead method