### PR TITLE
Car: update FW versions extension merging logic

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1,6 +1,8 @@
 from opendbc.car.structs import CarParams
 from opendbc.car.hyundai.values import CAR
+
 from opendbc.sunnypilot.car.fw_versions_ext import merge_fw_versions
+from opendbc.sunnypilot.car.hyundai.fingerprints_ext import FW_VERSIONS_EXT
 
 Ecu = CarParams.Ecu
 
@@ -1241,4 +1243,4 @@ FW_VERSIONS = {
   },
 }
 
-FW_VERSIONS = merge_fw_versions(FW_VERSIONS)
+FW_VERSIONS = merge_fw_versions(FW_VERSIONS, FW_VERSIONS_EXT)

--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1241,4 +1241,4 @@ FW_VERSIONS = {
   },
 }
 
-merge_fw_versions(FW_VERSIONS)
+FW_VERSIONS = merge_fw_versions(FW_VERSIONS)

--- a/opendbc/sunnypilot/car/fw_versions_ext.py
+++ b/opendbc/sunnypilot/car/fw_versions_ext.py
@@ -1,47 +1,9 @@
-import os
-from enum import StrEnum
-from typing import Any
-
-from opendbc.car.common.basedir import BASEDIR
-
-INTERFACE_EXT_ATTR_FILE = {
-  "FW_VERSIONS_EXT": "fingerprints_ext",
-}
-
-
-def get_interface_ext_attr(attr: str, combine_brands: bool = False, ignore_none: bool = False) -> dict[str | StrEnum, Any]:
-  # read all the folders in opendbc/car and return a dict where:
-  # - keys are all the car models or brand names
-  # - values are attr values from all car folders
-  result = {}
-  for car_folder in sorted([x[0] for x in os.walk(BASEDIR)]):
-    try:
-      brand_name = car_folder.split('/')[-1]
-      brand_values = __import__(f'opendbc.sunnypilot.car.{brand_name}.{INTERFACE_EXT_ATTR_FILE.get(attr, "values")}', fromlist=[attr])
-      if hasattr(brand_values, attr) or not ignore_none:
-        attr_data = getattr(brand_values, attr, None)
-      else:
-        continue
-
-      if combine_brands:
-        if isinstance(attr_data, dict):
-          for f, v in attr_data.items():
-            result[f] = v
-      else:
-        result[brand_name] = attr_data
-    except (ImportError, OSError):
-      pass
-
-  return result
-
-
-def merge_fw_versions(fw_versions):
+def merge_fw_versions(fw_versions, new_fw_versions):
   """
     Merge firmware versions by extending lists for matching ECUs,
     adding all entries regardless of duplicates.
   """
-  FW_VERSIONS_EXT = get_interface_ext_attr('FW_VERSIONS_EXT', combine_brands=True, ignore_none=True)
-  for c, f in FW_VERSIONS_EXT.items():
+  for c, f in new_fw_versions.items():
     if c not in fw_versions:
       fw_versions[c] = f
       continue


### PR DESCRIPTION
## Summary by Sourcery

Refactor the merging logic for standard and external firmware versions.

Enhancements:
- Modify `merge_fw_versions` to accept external firmware versions directly as an argument.
- Update Hyundai fingerprints to explicitly import external firmware versions and pass them to the updated merge function.
- Remove the dynamic loading of external firmware versions from the common merge function.
- Relocate Hyundai-specific external firmware versions to a dedicated file within the sunnypilot structure.