### PR TITLE
Sync: `commaai/opendbc:master` into `sunnypilot/opendbc:master-new`

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -85,7 +85,7 @@
 |Honda|Fit 2018-20|Honda Sensing|[Upstream](#upstream)|
 |Honda|Freed 2020|Honda Sensing|[Upstream](#upstream)|
 |Honda|HR-V 2019-22|Honda Sensing|[Upstream](#upstream)|
-|Honda|HR-V 2023|All|[Upstream](#upstream)|
+|Honda|HR-V 2023-25|All|[Upstream](#upstream)|
 |Honda|Insight 2019-22|All|[Upstream](#upstream)|
 |Honda|Inspire 2018|All|[Upstream](#upstream)|
 |Honda|Odyssey 2018-20|Honda Sensing|[Upstream](#upstream)|

--- a/opendbc/car/honda/values.py
+++ b/opendbc/car/honda/values.py
@@ -189,7 +189,7 @@ class CAR(Platforms):
     {Bus.pt: 'honda_accord_2018_can_generated'},
   )
   HONDA_HRV_3G = HondaBoschPlatformConfig(
-    [HondaCarDocs("Honda HR-V 2023", "All")],
+    [HondaCarDocs("Honda HR-V 2023-25", "All")],
     CarSpecs(mass=3125 * CV.LB_TO_KG, wheelbase=2.61, steerRatio=15.2, centerToFrontRatio=0.41, tireStiffnessFactor=0.5),
     {Bus.pt: 'honda_civic_ex_2022_can_generated'},
     flags=HondaFlags.BOSCH_RADARLESS,

--- a/opendbc/sunnypilot/car/car_list.json
+++ b/opendbc/sunnypilot/car/car_list.json
@@ -942,13 +942,15 @@
     ],
     "package": "Honda Sensing"
   },
-  "Honda HR-V 2023": {
+  "Honda HR-V 2023-25": {
     "platform": "HONDA_HRV_3G",
     "make": "Honda",
     "brand": "honda",
     "model": "HR-V",
     "year": [
-      "2023"
+      "2023",
+      "2024",
+      "2025"
     ],
     "package": "All"
   },


### PR DESCRIPTION
Sync: commaai/openpilot:master into sunnypilot/sunnypilot:master-new

## Summary by Sourcery

Sync upstream changes from commaai/openpilot:master into sunnypilot/sunnypilot:master-new, including minor updates to constants, car support, and safety replay helpers

Enhancements:
- Moved ISO lateral acceleration constant to a centralized location in interfaces.py
- Added support for Tesla steering message in safety replay helpers

Documentation:
- Updated Honda HR-V model year range to 2023-25 in CARS.md

Chores:
- Removed redundant constant definitions
- Simplified lateral acceleration calculations