### PR TITLE
Sync personality with secoc follow distance

### DIFF
--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -1,6 +1,7 @@
 import copy
 import numpy as np
 
+from openpilot.common.params import Params
 from opendbc.can.can_define import CANDefine
 from opendbc.can.parser import CANParser
 from opendbc.car import Bus, DT_CTRL, create_button_events, structs
@@ -8,8 +9,8 @@ from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.common.filter_simple import FirstOrderFilter
 from opendbc.car.interfaces import CarStateBase
 from opendbc.car.toyota.values import ToyotaFlags, CAR, DBC, STEER_THRESHOLD, NO_STOP_TIMER_CAR, \
-                                                  TSS2_CAR, RADAR_ACC_CAR, EPS_SCALE, UNSUPPORTED_DSU_CAR
-
+                                                  TSS2_CAR, RADAR_ACC_CAR, EPS_SCALE, UNSUPPORTED_DSU_CAR, \
+                                                  SECOC_CAR
 ButtonType = structs.CarState.ButtonEvent.Type
 SteerControlType = structs.CarParams.SteerControlType
 
@@ -183,6 +184,8 @@ class CarState(CarStateBase):
 
     if self.CP.carFingerprint not in UNSUPPORTED_DSU_CAR:
       self.pcm_follow_distance = cp.vl["PCM_CRUISE_2"]["PCM_FOLLOW_DISTANCE"]
+      if self.CP.carFingerprint in SECOC_CAR:
+        Params().put_nonblocking('LongitudinalPersonality', str(int(max(3 - self.pcm_follow_distance, 0))))
 
     if self.CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR):
       # distance button is wired to the ACC module (camera or radar)


### PR DESCRIPTION
## Summary by Sourcery

Synchronise the longitudinal personality setting with the PCM cruise follow distance for SECOC-equipped Toyota vehicles

Enhancements:
- Import SECOC_CAR constant and conditionally apply behavior for those models
- Set the ‘LongitudinalPersonality’ parameter to max(3 - follow_distance, 0) for SECOC_CAR vehicles during state update