### PR TITLE
Toyota: SecOC follow distance to personality sync

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -91,7 +91,7 @@ class CarController(CarControllerBase, SecOCLongCarController):
     # *** control msgs ***
     can_sends = []
 
-    SecOCLongCarController.update(self, CS, can_sends, self.secoc_prev_reset_counter)
+    SecOCLongCarController.update(self, CS, CC, can_sends, self.secoc_prev_reset_counter)
 
     # *** handle secoc reset counter increase ***
     if self.CP.flags & ToyotaFlags.SECOC.value:

--- a/opendbc/sunnypilot/car/toyota/secoc_long.py
+++ b/opendbc/sunnypilot/car/toyota/secoc_long.py
@@ -75,8 +75,6 @@ class SecOCLongCarState:
       prev_distance_button = self.distance_button
       if self.desired_distance != pcm_follow_distance:
         self.distance_button = not self.distance_button
-      elif self.distance_button != 0:
-        self.distance_button = 0
 
       ret.buttonEvents = create_button_events(self.distance_button, prev_distance_button, {1: ButtonType.gapAdjustCruise})
 


### PR DESCRIPTION
This pull request introduces support for SECOC (Secure Onboard Communication) in Toyota vehicles by integrating a new `SecOCLongCarState` class and updating existing logic to handle SECOC-specific functionality. The changes include modifications to the car state and controller logic, as well as the addition of new methods for managing SECOC-related data.

### SECOC Integration:

* **Added `SecOCLongCarState` class**: Introduced a new class in `opendbc/sunnypilot/car/toyota/secoc_long.py` to manage SECOC-specific state, including desired distance and button events. This class includes methods for updating state and generating button events for cruise gap adjustment.

* **Integrated `SecOCLongCarState` into `CarState`**: Added an instance of `SecOCLongCarState` to the `CarState` class in `opendbc/car/toyota/carstate.py` and updated its state during the `update` method. [[1]](diffhunk://#diff-1ccbc55b1c5c2c27e90f1661da4c2935ffc544e8e9d8b16ab28e4a7a8f5b94dcR34) [[2]](diffhunk://#diff-1ccbc55b1c5c2c27e90f1661da4c2935ffc544e8e9d8b16ab28e4a7a8f5b94dcR65)

### Updates to SECOC Logic:

* **Modified distance button logic**: Updated the `update` method in `CarState` to handle SECOC-specific distance button behavior, ensuring compatibility with vehicles that support SECOC.

* **Enhanced `SecOCLongCarController`**: Updated the `update` method in `SecOCLongCarController` to include the `CC` parameter and set the desired distance for SECOC vehicles based on HUD control inputs. [[1]](diffhunk://#diff-dc03b1fc7156134429efc0cdced75bc227d0ceb8bbd0c55763022fb9db6794d9L94-R94) [[2]](diffhunk://#diff-5814b70e7cd59fcf3f3ff0cfa426f41c9bb2c1c278bf71c50d58b09ac4b54991R62-R92)

### Codebase Adjustments:

* **Imported SECOC-related modules**: Added necessary imports for SECOC functionality in `carstate.py` and `secoc_long.py`, including `SecOCLongCarState` and `create_button_events`. [[1]](diffhunk://#diff-1ccbc55b1c5c2c27e90f1661da4c2935ffc544e8e9d8b16ab28e4a7a8f5b94dcL11-R14) [[2]](diffhunk://#diff-5814b70e7cd59fcf3f3ff0cfa426f41c9bb2c1c278bf71c50d58b09ac4b54991L1-R5)