### PR TITLE
Hyundai: fix long tune upstream values

### DIFF
--- a/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 from opendbc.car import structs, DT_CTRL
 from opendbc.car.interfaces import CarStateBase
-from opendbc.car.hyundai.values import CarControllerParams
+from opendbc.car.hyundai.values import CarControllerParams, HyundaiFlags
 from opendbc.sunnypilot.car.hyundai.longitudinal.helpers import get_car_config, jerk_limited_integrator, ramp_update, JERK_THRESHOLD
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 
@@ -170,8 +170,12 @@ class LongitudinalController:
 
     # If custom tuning is disabled, use upstream fixed values
     if not self.enabled:
-      self.jerk_upper = 3.0
-      self.jerk_lower = 5.0 if long_control_state == LongCtrlState.pid else 1.0
+      if self.CP.flags & HyundaiFlags.CANFD:
+        self.jerk_upper = 3.0
+        self.jerk_lower = 5.0 if long_control_state == LongCtrlState.pid else 1.0
+      else:
+        self.jerk_upper = 3.0 if long_control_state == LongCtrlState.pid else 1.0
+        self.jerk_lower = 5.0
       return
 
     velocity = CS.out.vEgo

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
@@ -172,7 +172,7 @@ class LongitudinalController:
     if not self.enabled:
       if self.CP.flags & HyundaiFlags.CANFD:
         self.jerk_upper = 3.0
-        self.jerk_lower = 5.0 if long_control_state == LongCtrlState.pid else 1.0
+        self.jerk_lower = 5.0 if CC.enabled else 1.0
       else:
         self.jerk_upper = 3.0 if long_control_state == LongCtrlState.pid else 1.0
         self.jerk_lower = 5.0

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
@@ -170,9 +170,9 @@ class LongitudinalController:
 
     # If custom tuning is disabled, use upstream fixed values
     if not self.enabled:
-      jerk_limit = 3.0 if long_control_state == LongCtrlState.pid else 1.0
-      self.jerk_upper = jerk_limit
-      self.jerk_lower = 5.0
+      jerk_limit = 5.0 if long_control_state == LongCtrlState.pid else 1.0
+      self.jerk_upper = 3.0
+      self.jerk_lower = jerk_limit
       return
 
     velocity = CS.out.vEgo

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
@@ -170,9 +170,8 @@ class LongitudinalController:
 
     # If custom tuning is disabled, use upstream fixed values
     if not self.enabled:
-      jerk_limit = 5.0 if long_control_state == LongCtrlState.pid else 1.0
       self.jerk_upper = 3.0
-      self.jerk_lower = jerk_limit
+      self.jerk_lower = 5.0 if long_control_state == LongCtrlState.pid else 1.0
       return
 
     velocity = CS.out.vEgo

--- a/opendbc/sunnypilot/car/hyundai/tests/test_tuning_controller.py
+++ b/opendbc/sunnypilot/car/hyundai/tests/test_tuning_controller.py
@@ -52,8 +52,8 @@ class TestLongitudinalTuningController(unittest.TestCase):
     # Test with non-PID state
     self.controller.calculate_jerk(mock_CC, mock_CS, LongCtrlState.stopping)
     print(f"[Non-PID state] jerk_upper={self.controller.jerk_upper:.2f}, jerk_lower={self.controller.jerk_lower:.2f}")
-    self.assertEqual(self.controller.jerk_upper, 1.0)
-    self.assertEqual(self.controller.jerk_lower, 5.0)
+    self.assertEqual(self.controller.jerk_upper, 3.0)
+    self.assertEqual(self.controller.jerk_lower, 1.0)
 
   def test_make_jerk_flag_on(self):
     """Only verify that limits update when flags are on."""


### PR DESCRIPTION
## Summary by Sourcery

Fix incorrect jerk limit assignments in Hyundai longitudinal controller when custom tuning is disabled

Bug Fixes:
- Always set jerk_upper to 3.0 and assign jerk_lower based on the control state when custom tuning is disabled in the Hyundai controller

Tests:
- Update unit test assertions to expect the new jerk_upper and jerk_lower values for non-PID state