### PR TITLE
MADS: use universal check for new Tesla angle command checks

### DIFF
--- a/opendbc/safety/modes/tesla.h
+++ b/opendbc/safety/modes/tesla.h
@@ -45,7 +45,7 @@ static bool tesla_steer_angle_cmd_checks(int desired_angle, bool steer_control_e
 
   bool violation = false;
 
-  if (controls_allowed && steer_control_enabled) {
+  if (is_lat_active() && steer_control_enabled) {
     // *** ISO lateral jerk limit ***
     // calculate maximum angle rate per second
     const float speed = MAX(fudged_speed, 1.0);
@@ -80,7 +80,7 @@ static bool tesla_steer_angle_cmd_checks(int desired_angle, bool steer_control_e
   }
 
   // No angle control allowed when controls are not allowed
-  violation |= !controls_allowed && steer_control_enabled;
+  violation |= !is_lat_active() && steer_control_enabled;
 
   return violation;
 }

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -92,7 +92,7 @@ safety_config current_safety_config;
 static void generic_rx_checks(void);
 static void stock_ecu_check(bool stock_ecu_detected);
 
-static bool is_lat_active(void) {
+bool is_lat_active(void) {
   return controls_allowed || mads_is_lateral_control_allowed_by_mads();
 }
 

--- a/opendbc/safety/sunnypilot/safety_mads_declarations.h
+++ b/opendbc/safety/sunnypilot/safety_mads_declarations.h
@@ -114,3 +114,5 @@ extern void m_mads_state_init(void);
 extern void m_update_button_state(ButtonStateTracking *button_state);
 extern void m_update_binary_state(BinaryStateTracking *state);
 extern void m_update_control_state(void);
+
+bool is_lat_active(void);


### PR DESCRIPTION
## Summary by Sourcery

Unify lateral control permission checks by using the common is_lat_active function in Tesla steering command validation and expose that function project-wide.

Enhancements:
- Replace direct controls_allowed checks with is_lat_active in Tesla steer angle command validation
- Make is_lat_active globally visible by removing its static qualifier and adding a forward declaration in safety_mads_declarations.h