### PR TITLE
Hyundai Longitudinal: new low speed to stopping tuning

### DIFF
--- a/opendbc/sunnypilot/car/hyundai/longitudinal/config.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/config.py
@@ -24,15 +24,22 @@ class CarTuningConfig:
 
 # Default configurations for different car types
 TUNING_CONFIGS = {
-  "CANFD": CarTuningConfig(),
+  "CANFD": CarTuningConfig(
+    v_ego_stopping=0.365,
+    lookahead_jerk_bp=[2., 5., 20.],
+    lookahead_jerk_upper_v=[0.25, 0.5, 1.0],
+    lookahead_jerk_lower_v=[0.05, 0.10, 0.325],
+  ),
   "EV": CarTuningConfig(
-    lookahead_jerk_upper_v=[0.3, 1.0],
+    stopping_decel_rate=0.45,
+    v_ego_stopping=0.35,
+    lookahead_jerk_upper_v=[0.3, 0.7],
     lookahead_jerk_lower_v=[0.2, 0.4],
   ),
   "HYBRID": CarTuningConfig(
     v_ego_starting=0.15,
     stopping_decel_rate=0.45,
-    v_ego_stopping=0.35,
+    v_ego_stopping=0.4,
   ),
   "DEFAULT": CarTuningConfig(
     lookahead_jerk_bp=[2., 5., 20.],

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
@@ -105,7 +105,7 @@ class LongitudinalController:
       upper_limit = 0.5  # Default for non-PID states
 
     # Lower jerk limit varies based on speed
-    lower_limit = float(np.interp(velocity, [0.0, 5.0, 20.0], [5.0, 5.0, 2.5]))
+    lower_limit = float(np.interp(velocity, [0.0, 5.0, 20.0], [5.0, 4.0, 2.5]))
 
     return upper_limit, lower_limit
 


### PR DESCRIPTION
This PR aims to resolve issues users report on not stopping when vehicle reaches 2 mph.

## Summary by Sourcery

Update Hyundai longitudinal tuning parameters to ensure reliable stopping at low speeds by raising stopping thresholds, adjusting deceleration rates, and refining jerk limits.

Bug Fixes:
- Fix failure to come to a complete stop around 2 mph by tuning stopping speed and deceleration parameters.

Enhancements:
- Adjust default stopping speed thresholds and jerk profile breakpoints for CANFD, EV, and HYBRID configurations.
- Refine lower jerk limit interpolation curve to reduce excessive jerk at low speeds.