### PR TITLE
Car: `CarStateSP`

### DIFF
--- a/opendbc/car/body/carstate.py
+++ b/opendbc/car/body/carstate.py
@@ -5,9 +5,10 @@ from opendbc.car.body.values import DBC
 
 
 class CarState(CarStateBase):
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.main]
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
 
     ret.wheelSpeeds.fl = cp.vl['MOTORS_DATA']['SPEED_L']
     ret.wheelSpeeds.fr = cp.vl['MOTORS_DATA']['SPEED_R']
@@ -28,7 +29,7 @@ class CarState(CarStateBase):
     ret.cruiseState.enabled = True
     ret.cruiseState.available = True
 
-    return ret
+    return ret, ret_sp
 
   @staticmethod
   def get_can_parsers(CP, CP_SP):

--- a/opendbc/car/chrysler/carstate.py
+++ b/opendbc/car/chrysler/carstate.py
@@ -28,11 +28,12 @@ class CarState(CarStateBase, MadsCarState):
 
     self.distance_button = 0
 
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
     cp_cam = can_parsers[Bus.cam]
 
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
 
     prev_distance_button = self.distance_button
     self.distance_button = cp.vl["CRUISE_BUTTONS"]["ACC_Distance_Dec"]
@@ -114,7 +115,7 @@ class CarState(CarStateBase, MadsCarState):
       *create_button_events(self.lkas_button, self.prev_lkas_button, {1: ButtonType.lkas}),
     ]
 
-    return ret
+    return ret, ret_sp
 
   @staticmethod
   def get_cruise_messages():

--- a/opendbc/car/ford/carstate.py
+++ b/opendbc/car/ford/carstate.py
@@ -24,11 +24,12 @@ class CarState(CarStateBase, MadsCarState):
     self.distance_button = 0
     self.lc_button = 0
 
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
     cp_cam = can_parsers[Bus.cam]
 
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
 
     # Occasionally on startup, the ABS module recalibrates the steering pinion offset, so we need to block engagement
     # The vehicle usually recovers out of this state within a minute of normal driving
@@ -122,7 +123,7 @@ class CarState(CarStateBase, MadsCarState):
       *create_button_events(self.distance_button, prev_distance_button, {1: ButtonType.gapAdjustCruise}),
       *create_button_events(self.lc_button, prev_lc_button, {1: ButtonType.lkas}),
     ]
-    return ret
+    return ret, ret_sp
 
   @staticmethod
   def get_can_parsers(CP, CP_SP):

--- a/opendbc/car/gm/carstate.py
+++ b/opendbc/car/gm/carstate.py
@@ -42,12 +42,13 @@ class CarState(CarStateBase):
           return True
     return False
 
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     pt_cp = can_parsers[Bus.pt]
     cam_cp = can_parsers[Bus.cam]
     loopback_cp = can_parsers[Bus.loopback]
 
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
 
     prev_cruise_buttons = self.cruise_buttons
     prev_distance_button = self.distance_button
@@ -161,7 +162,7 @@ class CarState(CarStateBase):
     if ret.vEgo < self.CP.minSteerSpeed:
       ret.lowSpeedAlert = True
 
-    return ret
+    return ret, ret_sp
 
   @staticmethod
   def get_can_parsers(CP, CP_SP):

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -110,13 +110,14 @@ class CarState(CarStateBase):
     # However, on cars without a digital speedometer this is not always present (HRV, FIT, CRV 2016, ILX and RDX)
     self.dash_speed_seen = False
 
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
     cp_cam = can_parsers[Bus.cam]
     if self.CP.enableBsm:
       cp_body = can_parsers[Bus.body]
 
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
 
     # car params
     v_weight_v = [0., 1.]  # don't trust smooth speed at low values to avoid premature zero snapping
@@ -281,7 +282,7 @@ class CarState(CarStateBase):
       *create_button_events(self.cruise_setting, prev_cruise_setting, SETTINGS_BUTTONS_DICT),
     ]
 
-    return ret
+    return ret, ret_sp
 
   def get_can_parsers(self, CP, CP_SP):
     pt_messages = get_can_messages(CP, self.gearbox_msg)

--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -77,7 +77,7 @@ class CarState(CarStateBase, EsccCarStateBase, MadsCarState, CarStateExt):
     # Main button also can trigger an engagement on these cars
     return any(btn in ENABLE_BUTTONS for btn in self.cruise_buttons) or any(self.main_buttons)
 
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
     cp_cam = can_parsers[Bus.cam]
 
@@ -85,6 +85,7 @@ class CarState(CarStateBase, EsccCarStateBase, MadsCarState, CarStateExt):
       return self.update_canfd(can_parsers)
 
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
     cp_cruise = cp_cam if self.CP.flags & HyundaiFlags.CAMERA_SCC else cp
     self.is_metric = cp.vl["CLU11"]["CF_Clu_SPEED_UNIT"] == 0
     speed_conv = CV.KPH_TO_MS if self.is_metric else CV.MPH_TO_MS
@@ -220,13 +221,14 @@ class CarState(CarStateBase, EsccCarStateBase, MadsCarState, CarStateExt):
       self.low_speed_alert = False
     ret.lowSpeedAlert = self.low_speed_alert
 
-    return ret
+    return ret, ret_sp
 
-  def update_canfd(self, can_parsers) -> structs.CarState:
+  def update_canfd(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
     cp_cam = can_parsers[Bus.cam]
 
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
 
     self.is_metric = cp.vl["CRUISE_BUTTONS_ALT"]["DISTANCE_UNIT"] != 1
     speed_factor = CV.KPH_TO_MS if self.is_metric else CV.MPH_TO_MS
@@ -322,7 +324,7 @@ class CarState(CarStateBase, EsccCarStateBase, MadsCarState, CarStateExt):
 
     ret.blockPcmEnable = not self.recent_button_interaction()
 
-    return ret
+    return ret, ret_sp
 
   def get_can_parsers_canfd(self, CP):
     pt_messages = [

--- a/opendbc/car/mazda/carstate.py
+++ b/opendbc/car/mazda/carstate.py
@@ -21,11 +21,12 @@ class CarState(CarStateBase):
 
     self.distance_button = 0
 
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
     cp_cam = can_parsers[Bus.cam]
 
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
 
     prev_distance_button = self.distance_button
     self.distance_button = cp.vl["CRZ_BTNS"]["DISTANCE_LESS"]
@@ -119,7 +120,7 @@ class CarState(CarStateBase):
     # TODO: add button types for inc and dec
     ret.buttonEvents = create_button_events(self.distance_button, prev_distance_button, {1: ButtonType.gapAdjustCruise})
 
-    return ret
+    return ret, ret_sp
 
   @staticmethod
   def get_can_parsers(CP, CP_SP):

--- a/opendbc/car/mock/carstate.py
+++ b/opendbc/car/mock/carstate.py
@@ -3,5 +3,5 @@ from opendbc.car.interfaces import CarStateBase
 
 
 class CarState(CarStateBase):
-  def update(self, *_) -> structs.CarState:
-    return structs.CarState()
+  def update(self, *_) -> tuple[structs.CarState, structs.CarStateSP]:
+    return structs.CarState(), structs.CarStateSP()

--- a/opendbc/car/nissan/carstate.py
+++ b/opendbc/car/nissan/carstate.py
@@ -25,12 +25,13 @@ class CarState(CarStateBase):
 
     self.distance_button = 0
 
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
     cp_cam = can_parsers[Bus.cam]
     cp_adas = can_parsers[Bus.adas]
 
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
 
     prev_distance_button = self.distance_button
     self.distance_button = cp.vl["CRUISE_THROTTLE"]["FOLLOW_DISTANCE_BUTTON"]
@@ -133,7 +134,7 @@ class CarState(CarStateBase):
 
     ret.buttonEvents = create_button_events(self.distance_button, prev_distance_button, {1: ButtonType.gapAdjustCruise})
 
-    return ret
+    return ret, ret_sp
 
   @staticmethod
   def get_can_parsers(CP, CP_SP):

--- a/opendbc/car/rivian/carstate.py
+++ b/opendbc/car/rivian/carstate.py
@@ -17,11 +17,12 @@ class CarState(CarStateBase):
     self.sccm_wheel_touch = None
     self.vdm_adas_status = None
 
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
     cp_cam = can_parsers[Bus.cam]
     cp_adas = can_parsers[Bus.adas]
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
 
     # Vehicle speed
     ret.vEgoRaw = cp.vl["ESP_Status"]["ESP_Vehicle_Speed"] * CV.KPH_TO_MS
@@ -89,7 +90,7 @@ class CarState(CarStateBase):
     self.sccm_wheel_touch = copy.copy(cp.vl["SCCM_WheelTouch"])
     self.vdm_adas_status = copy.copy(cp.vl["VDM_AdasSts"])
 
-    return ret
+    return ret, ret_sp
 
   @staticmethod
   def get_can_parsers(CP, CP_SP):

--- a/opendbc/car/structs.py
+++ b/opendbc/car/structs.py
@@ -103,3 +103,8 @@ class CarControlSP:
   class Param:
     key: str = auto_field()
     value: str = auto_field()
+
+
+@auto_dataclass
+class CarStateSP:
+  speedLimit: float = auto_field()

--- a/opendbc/car/structs.py
+++ b/opendbc/car/structs.py
@@ -107,4 +107,4 @@ class CarControlSP:
 
 @auto_dataclass
 class CarStateSP:
-  speedLimit: float = auto_field()
+  pass

--- a/opendbc/car/subaru/carstate.py
+++ b/opendbc/car/subaru/carstate.py
@@ -19,11 +19,12 @@ class CarState(CarStateBase, MadsCarState):
 
     self.angle_rate_calulator = CanSignalRateCalculator(50)
 
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
     cp_cam = can_parsers[Bus.cam]
     cp_alt = can_parsers[Bus.alt]
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
 
     throttle_msg = cp.vl["Throttle"] if not (self.CP.flags & SubaruFlags.HYBRID) else cp_alt.vl["Throttle_Hybrid"]
     ret.gas = throttle_msg["Throttle_Pedal"] / 255.
@@ -133,7 +134,7 @@ class CarState(CarStateBase, MadsCarState):
 
     MadsCarState.update_mads(self, ret, can_parsers)
 
-    return ret
+    return ret, ret_sp
 
   @staticmethod
   def get_common_global_body_messages(CP):

--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -31,10 +31,11 @@ class CarState(CarStateBase):
     self.autopark_prev = autopark_now
     self.cruise_enabled_prev = cruise_enabled
 
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp_party = can_parsers[Bus.party]
     cp_ap_party = can_parsers[Bus.ap_party]
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
 
     # Vehicle speed
     ret.vEgoRaw = cp_party.vl["DI_speed"]["DI_vehicleSpeed"] * CV.KPH_TO_MS
@@ -118,7 +119,7 @@ class CarState(CarStateBase):
     # Messages needed by carcontroller
     self.das_control = copy.copy(cp_ap_party.vl["DAS_control"])
 
-    return ret
+    return ret, ret_sp
 
   @staticmethod
   def get_can_parsers(CP, CP_SP):

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -53,11 +53,12 @@ class CarState(CarStateBase):
     self.gvc = 0.0
     self.secoc_synchronization = None
 
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
     cp_cam = can_parsers[Bus.cam]
 
     ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
     cp_acc = cp_cam if self.CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR) else cp
 
     if not self.CP.flags & ToyotaFlags.SECOC.value:
@@ -192,7 +193,7 @@ class CarState(CarStateBase):
 
       ret.buttonEvents = create_button_events(self.distance_button, prev_distance_button, {1: ButtonType.gapAdjustCruise})
 
-    return ret
+    return ret, ret_sp
 
   @staticmethod
   def get_can_parsers(CP, CP_SP):


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new CarStateSP data structure and extend all car state update methods to return both CarState and CarStateSP, adapting interfaces and parsers accordingly.

New Features:
- Add a placeholder CarStateSP dataclass to represent a secondary car state.

Enhancements:
- Update CarStateBase, CarInterface, and every model-specific carstate update method to return a tuple of (CarState, CarStateSP).
- Instantiate and propagate ret_sp alongside ret in both CAN and CAN-FD update paths for all supported car brands.