### PR TITLE
Hyundai CAN: Remove `dashcamOnly`

### DIFF
--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -176,6 +176,8 @@ class CarInterface(CarInterfaceBase):
     if stock_cp.flags & (HyundaiFlags.CANFD_CAMERA_SCC | HyundaiFlags.CAMERA_SCC):
       stock_cp.radarUnavailable = False
 
+    stock_cp.dashcamOnly = False
+
     return ret
 
   @staticmethod

--- a/opendbc/sunnypilot/car/car_list.json
+++ b/opendbc/sunnypilot/car/car_list.json
@@ -1348,6 +1348,16 @@
     ],
     "package": "Smart Cruise Control (SCC)"
   },
+  "Hyundai Kona 2022": {
+    "platform": "HYUNDAI_KONA_2022",
+    "make": "Hyundai",
+    "brand": "hyundai",
+    "model": "Kona",
+    "year": [
+      "2022"
+    ],
+    "package": "Smart Cruise Control (SCC)"
+  },
   "Hyundai Kona Electric 2018-21": {
     "platform": "HYUNDAI_KONA_EV",
     "make": "Hyundai",
@@ -1907,6 +1917,16 @@
       "2020"
     ],
     "package": "Smart Cruise Control (SCC)"
+  },
+  "Kia Optima Hybrid 2017": {
+    "platform": "KIA_OPTIMA_H",
+    "make": "Kia",
+    "brand": "hyundai",
+    "model": "Optima Hybrid",
+    "year": [
+      "2017"
+    ],
+    "package": "Advanced Smart Cruise Control"
   },
   "Kia Optima Hybrid 2019": {
     "platform": "KIA_OPTIMA_H_G4_FL",


### PR DESCRIPTION
## Summary by Sourcery

Initialize the new dashcamOnly flag in Hyundai CarParams and update the car_list.json to include dashcam-only models.

Enhancements:
- Set dashcamOnly to False by default in the Hyundai interface parameter getter.

Chores:
- Add relevant entries for dashcam-only support in the car_list.json.