### PR TITLE
Hyundai CAN: Optima should still be in `dashcamOnly`

### DIFF
--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -176,8 +176,6 @@ class CarInterface(CarInterfaceBase):
     if stock_cp.flags & (HyundaiFlags.CANFD_CAMERA_SCC | HyundaiFlags.CAMERA_SCC):
       stock_cp.radarUnavailable = False
 
-    stock_cp.dashcamOnly = False
-
     return ret
 
   @staticmethod

--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -176,6 +176,9 @@ class CarInterface(CarInterfaceBase):
     if stock_cp.flags & (HyundaiFlags.CANFD_CAMERA_SCC | HyundaiFlags.CAMERA_SCC):
       stock_cp.radarUnavailable = False
 
+    if stock_cp.flags & HyundaiFlags.ALT_LIMITS_2:
+      stock_cp.dashcamOnly = False
+
     return ret
 
   @staticmethod

--- a/opendbc/sunnypilot/car/car_list.json
+++ b/opendbc/sunnypilot/car/car_list.json
@@ -1348,6 +1348,16 @@
     ],
     "package": "Smart Cruise Control (SCC)"
   },
+  "Hyundai Kona 2022": {
+    "platform": "HYUNDAI_KONA_2022",
+    "make": "Hyundai",
+    "brand": "hyundai",
+    "model": "Kona",
+    "year": [
+      "2022"
+    ],
+    "package": "Smart Cruise Control (SCC)"
+  },
   "Hyundai Kona Electric 2018-21": {
     "platform": "HYUNDAI_KONA_EV",
     "make": "Hyundai",

--- a/opendbc/sunnypilot/car/car_list.json
+++ b/opendbc/sunnypilot/car/car_list.json
@@ -1348,16 +1348,6 @@
     ],
     "package": "Smart Cruise Control (SCC)"
   },
-  "Hyundai Kona 2022": {
-    "platform": "HYUNDAI_KONA_2022",
-    "make": "Hyundai",
-    "brand": "hyundai",
-    "model": "Kona",
-    "year": [
-      "2022"
-    ],
-    "package": "Smart Cruise Control (SCC)"
-  },
   "Hyundai Kona Electric 2018-21": {
     "platform": "HYUNDAI_KONA_EV",
     "make": "Hyundai",
@@ -1917,16 +1907,6 @@
       "2020"
     ],
     "package": "Smart Cruise Control (SCC)"
-  },
-  "Kia Optima Hybrid 2017": {
-    "platform": "KIA_OPTIMA_H",
-    "make": "Kia",
-    "brand": "hyundai",
-    "model": "Optima Hybrid",
-    "year": [
-      "2017"
-    ],
-    "package": "Advanced Smart Cruise Control"
   },
   "Kia Optima Hybrid 2019": {
     "platform": "KIA_OPTIMA_H_G4_FL",


### PR DESCRIPTION
Reverts sunnypilot/opendbc#182

## Summary by Sourcery

Bug Fixes:
- Reintroduce the default assignment of dashcamOnly to false for Hyundai vehicles to restore expected behavior