### PR TITLE
Hyundai Longitudinal: New tuning for KIA_NIRO_PHEV_2022

### DIFF
--- a/opendbc/sunnypilot/car/hyundai/longitudinal/config.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/config.py
@@ -56,6 +56,12 @@ CAR_SPECIFIC_CONFIGS = {
     lookahead_jerk_lower_v=[0.2, 0.4],
     jerk_limits=2.5,
   ),
+  CAR.KIA_NIRO_PHEV_2022: CarTuningConfig(
+    stopping_decel_rate=0.3,
+    lookahead_jerk_upper_v=[0.3, 1.0],
+    lookahead_jerk_lower_v=[0.15, 0.3],
+    jerk_limits=4.0,
+  ),
   CAR.HYUNDAI_IONIQ: CarTuningConfig(
     jerk_limits=4.5,
   )


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce longitudinal tuning configuration for KIA_NIRO_PHEV_2022 with custom deceleration and jerk limits