### PR TITLE
Hyundai Longitudinal: Comfort Band adjustments

### DIFF
--- a/opendbc/sunnypilot/car/hyundai/longitudinal/config.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/config.py
@@ -56,6 +56,12 @@ CAR_SPECIFIC_CONFIGS = {
     lookahead_jerk_lower_v=[0.2, 0.4],
     jerk_limits=2.5,
   ),
+  CAR.KIA_NIRO_PHEV_2022: CarTuningConfig(
+    stopping_decel_rate=0.3,
+    lookahead_jerk_upper_v=[0.3, 1.0],
+    lookahead_jerk_lower_v=[0.15, 0.3],
+    jerk_limits=4.0,
+  ),
   CAR.HYUNDAI_IONIQ: CarTuningConfig(
     jerk_limits=4.5,
   )

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/config.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/config.py
@@ -56,12 +56,6 @@ CAR_SPECIFIC_CONFIGS = {
     lookahead_jerk_lower_v=[0.2, 0.4],
     jerk_limits=2.5,
   ),
-  CAR.KIA_NIRO_PHEV_2022: CarTuningConfig(
-    stopping_decel_rate=0.3,
-    lookahead_jerk_upper_v=[0.3, 1.0],
-    lookahead_jerk_lower_v=[0.15, 0.3],
-    jerk_limits=4.0,
-  ),
   CAR.HYUNDAI_IONIQ: CarTuningConfig(
     jerk_limits=4.5,
   )

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from opendbc.car import structs, DT_CTRL
 from opendbc.car.interfaces import CarStateBase
 from opendbc.car.hyundai.values import CarControllerParams
-from opendbc.sunnypilot.car.hyundai.longitudinal.helpers import get_car_config, jerk_limited_integrator, ramp_update, JERK_THRESHOLD
+from opendbc.sunnypilot.car.hyundai.longitudinal.helpers import get_car_config, jerk_limited_integrator, ramp_update
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 
 LongCtrlState = structs.CarControl.Actuators.LongControlState
@@ -251,7 +251,7 @@ class LongitudinalController:
       self.comfort_band_lower = 0.0
       return
 
-    self.comfort_band_upper = JERK_THRESHOLD
+    self.comfort_band_upper = 0.01
     self.comfort_band_lower = 0.01
 
   def get_tuning_state(self) -> None:

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
@@ -17,6 +17,7 @@ from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 LongCtrlState = structs.CarControl.Actuators.LongControlState
 
 MIN_JERK = 0.5
+COMFORT_BAND_VAL = 0.01
 
 DYNAMIC_LOWER_JERK_BP = [-2.0, -1.5, -1.0, -0.25, -0.1, -0.025, -0.01, -0.005]
 DYNAMIC_LOWER_JERK_V  = [ 3.3,  2.5,  2.0,   1.9,  1.8,   1.65,  1.15,    0.5]
@@ -251,8 +252,8 @@ class LongitudinalController:
       self.comfort_band_lower = 0.0
       return
 
-    self.comfort_band_upper = 0.01
-    self.comfort_band_lower = 0.01
+    self.comfort_band_upper = COMFORT_BAND_VAL
+    self.comfort_band_lower = COMFORT_BAND_VAL
 
   def get_tuning_state(self) -> None:
     """Update the tuning state object with current control values.

--- a/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
+++ b/opendbc/sunnypilot/car/hyundai/longitudinal/controller.py
@@ -252,7 +252,7 @@ class LongitudinalController:
       return
 
     self.comfort_band_upper = JERK_THRESHOLD
-    self.comfort_band_lower = JERK_THRESHOLD
+    self.comfort_band_lower = 0.01
 
   def get_tuning_state(self) -> None:
     """Update the tuning state object with current control values.


### PR DESCRIPTION
## Summary by Sourcery

Update the default comfort band bounds in the Hyundai longitudinal controller to use a new fixed constant value.

Enhancements:
- Introduce a new COMFORT_BAND_VAL constant (0.01) for comfort band limits
- Apply COMFORT_BAND_VAL to both upper and lower comfort bands instead of JERK_THRESHOLD

Chores:
- Remove unused JERK_THRESHOLD import from helpers