### PR TITLE
Rivian: use vEgoCluster

### DIFF
--- a/opendbc/sunnypilot/car/rivian/carstate_ext.py
+++ b/opendbc/sunnypilot/car/rivian/carstate_ext.py
@@ -66,7 +66,7 @@ class CarStateExt:
           self.set_speed -= CV.MPH_TO_MS
 
       if not ret.cruiseState.enabled:
-        self.set_speed = ret.vEgo
+        self.set_speed = ret.vEgoCluster
 
       self.set_speed = max(MIN_SET_SPEED, min(self.set_speed, MAX_SET_SPEED))
       ret.cruiseState.speed = self.set_speed


### PR DESCRIPTION
When using vEgoCluster, we are closer to the true set speed of the Rivian.