### PR TITLE
mads: cleanup invalid super().init()

### DIFF
--- a/opendbc/sunnypilot/car/hyundai/mads.py
+++ b/opendbc/sunnypilot/car/hyundai/mads.py
@@ -24,7 +24,6 @@ MadsDataSP = namedtuple("MadsDataSP",
 
 class MadsCarController:
   def __init__(self):
-    super().__init__()
     self.mads = MadsDataSP(False, False, False, False)
 
     self.lat_disengage_blink = 0


### PR DESCRIPTION
- Cleans up redundant `super().__init__()` call.

## Summary by Sourcery

Enhancements:
- Remove redundant super().__init__() invocation from MadsCarController constructor