### PR TITLE
`carControlSP`: parse `radarState`'s `leadOne` & `leadTwo`

### DIFF
--- a/opendbc/car/structs.py
+++ b/opendbc/car/structs.py
@@ -110,7 +110,7 @@ class LeadData:
   aLeadTau: float = auto_field()
   modelProb: float = auto_field()
   radar: bool = auto_field()
-  radarTracksId: int = auto_field()
+  radarTrackId: int = auto_field()
 
   aLeadDEPRECATED: float = auto_field()
 


### PR DESCRIPTION
- Split from https://github.com/sunnypilot/opendbc/pull/139

## Summary by Sourcery

Add LeadData dataclass to encapsulate radar lead data and integrate leadOne and leadTwo fields into CarControlSP

New Features:
- Introduce LeadData dataclass with comprehensive radar lead attributes
- Add leadOne and leadTwo fields of type LeadData to CarControlSP