### PR TITLE
docker: sunnypilot images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,15 +67,15 @@ jobs:
       matrix:
         job: [0, 1, 2, 3]
     env:
-      BASE_IMAGE: openpilot-base
-      BUILD: selfdrive/test/docker_build.sh base
+      BASE_IMAGE: sunnypilot-base
+      BUILD: release/ci/docker_build_sp.sh base
       RUN: docker run --shm-size 2G -v $PWD:/tmp/openpilot -w /tmp/openpilot -e CI=1 -e PYTHONWARNINGS=error -e FILEREADER_CACHE=1 -e PYTHONPATH=/tmp/openpilot -e NUM_JOBS -e JOB_ID -e GITHUB_ACTION -e GITHUB_REF -e GITHUB_HEAD_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_RUN_ID -v $GITHUB_WORKSPACE/.ci_cache/scons_cache:/tmp/scons_cache -v $GITHUB_WORKSPACE/.ci_cache/comma_download_cache:/tmp/comma_download_cache -v $GITHUB_WORKSPACE/.ci_cache/openpilot_cache:/tmp/openpilot_cache $BASE_IMAGE /bin/bash -c
       PYTEST: pytest --continue-on-collection-errors --durations=0 --durations-min=5 -n logical
     steps:
     - uses: actions/checkout@v4
       with:
         repository: 'sunnypilot/sunnypilot'
-        ref: '479f91f333319f81712374de6d03d2e3ca73242a'
+        ref: 'master'
         submodules: true
     - run: rm -rf opendbc_repo/
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions tests workflow to use Sunnypilot docker image and build script, and point repository checkout to master

Enhancements:
- Switch CI docker base image to sunnypilot-base and use the Sunnypilot-specific build script

CI:
- Update tests workflow to checkout from master instead of a fixed commit