### PR TITLE
Hyundai Longitudinal: allow radar tracks to enable with ESCC installed

### DIFF
--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -168,7 +168,7 @@ def get_car(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_multip
   CP.fuzzyFingerprint = not exact_match
   CP_SP = CarInterface.get_params_sp(CP, candidate, fingerprints, car_fw, alpha_long_allowed, docs=False)
 
-  sunnypilot_interfaces(CP, can_recv, can_send)
+  sunnypilot_interfaces(CP, CP_SP, can_recv, can_send)
 
   return interfaces[CP.carFingerprint](CP, CP_SP)
 

--- a/opendbc/sunnypilot/car/interfaces.py
+++ b/opendbc/sunnypilot/car/interfaces.py
@@ -8,14 +8,15 @@ from opendbc.car import structs
 from opendbc.car.can_definitions import CanRecvCallable, CanSendCallable
 from opendbc.car.hyundai.values import HyundaiFlags
 from opendbc.sunnypilot.car.hyundai.enable_radar_tracks import enable_radar_tracks as hyundai_enable_radar_tracks
+from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 
 
-def setup_interfaces(CP: structs.CarParams, can_recv: CanRecvCallable = None, can_send: CanSendCallable = None) -> None:
-  _initialize_radar_tracks(CP, can_recv, can_send)
+def setup_interfaces(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_recv: CanRecvCallable = None, can_send: CanSendCallable = None) -> None:
+  _initialize_radar_tracks(CP, CP_SP, can_recv, can_send)
 
 
-def _initialize_radar_tracks(CP: structs.CarParams, can_recv: CanRecvCallable = None, can_send: CanSendCallable = None) -> None:
+def _initialize_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_recv: CanRecvCallable = None, can_send: CanSendCallable = None) -> None:
   if CP.brand == 'hyundai':
-    if CP.flags & HyundaiFlags.MANDO_RADAR and CP.radarUnavailable:
+    if CP.flags & HyundaiFlags.MANDO_RADAR and (CP.radarUnavailable or CP_SP.flags & HyundaiFlagsSP.ENHANCED_SCC):
       tracks_enabled = hyundai_enable_radar_tracks(can_recv, can_send, bus=0, addr=0x7d0)
       CP.radarUnavailable = not tracks_enabled


### PR DESCRIPTION
## Summary by Sourcery

Enable radar tracks on Hyundai vehicles equipped with Enhanced Smart Cruise Control by extending interface initialization to accept CarParamsSP and incorporating the ESCC flag into the radar enabling logic.

Enhancements:
- Allow radar tracks initialization for Hyundai vehicles with enhanced SCC (ESCC) installed by checking HyundaiFlagsSP.ENHANCED_SCC
- Update setup_interfaces and _initialize_radar_tracks signatures to accept CarParamsSP and propagate it from car_helpers to sunnypilot interfaces