### PR TITLE
HKG: Added fingerprint of HYUNDAI KONA 2023 

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1250,10 +1250,12 @@ FW_VERSIONS = {
   CAR.HYUNDAI_KONA_2022: {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00OSP LKA  AT USA LHD 1.00 1.04 99211-J9200 904',
+      b'\xf1\x00OSP LKA  AT CND LHD 1.00 1.04 99211-J9200 904',  
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00OSP MDPS C 1.00 1.04 56310/J9290 4OPCC104',
       b'\xf1\x00OSP MDPS C 1.00 1.04 56310/J9291 4OPCC104',
+      b'\xf1\x00OSP MDPS C 1.00 1.04 56310J9291\x00 4OPCC104',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00YB__ FCA -----      1.00 1.01 99110-J9000      \x00\x00\x00',
@@ -1262,6 +1264,7 @@ FW_VERSIONS = {
       b'\xf1\x00T01960BL  T01E60A1  DOS2T16X4XE60NS4N\x90\xe6\xcb',
       b'\xf1\x00T01G00BL  T01I00A1  DOS2T16X2XI00NS0\x8c`\xff\xe7',
       b'\xf1\x00T01G00BL  T01I00A1  DOS2T16X4XI00NS0\x99L\xeeq',
+      b'\xf1\x00HT6WA280BLHT6VA650A1COS4N20NS1\x00\x00\x00\x00\x00\x00\x15\xf5\x87~',
     ],
   },
 }

--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -260,10 +260,10 @@ class CAR(Platforms):
     CarSpecs(mass=1685, wheelbase=2.6, steerRatio=13.42, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.EV | HyundaiFlags.ALT_LIMITS,
   )
-  HYUNDAI_KONA_EV_2022 = HyundaiPlatformConfig(
-    [HyundaiCarDocs("Hyundai Kona Electric 2022-23", car_parts=CarParts.common([CarHarness.hyundai_o]))],
-    CarSpecs(mass=1743, wheelbase=2.6, steerRatio=13.42, tireStiffnessFactor=0.385),
-    flags=HyundaiFlags.CAMERA_SCC | HyundaiFlags.EV | HyundaiFlags.ALT_LIMITS,
+  HYUNDAI_KONA_2022 = HyundaiPlatformConfig(
+    [HyundaiCarDocs("Hyundai Kona 2022-23", car_parts=CarParts.common([CarHarness.hyundai_o]))],
+    CarSpecs(mass=1491, wheelbase=2.6, steerRatio=13.42, tireStiffnessFactor=0.385),
+    flags=HyundaiFlags.CAMERA_SCC | HyundaiFlags.ALT_LIMITS,
   )
   HYUNDAI_KONA_EV_2ND_GEN = HyundaiCanFDPlatformConfig(
     [HyundaiCarDocs("Hyundai Kona Electric (with HDA II, Korea only) 2023", video="https://www.youtube.com/watch?v=U2fOCmcQ8hw",


### PR DESCRIPTION
Validation
* Dongle ID: 586e8c118ec2a586
* Route: 586e8c118ec2a586/00000014--438d241d66

## Summary by Sourcery

Add support for the 2023 Hyundai Kona by including new CAN fingerprints and update the existing Kona platform configuration label and limits flag.

New Features:
- Add CAN fingerprint entries for Hyundai Kona 2023 forward camera, EPS, and radar modules

Enhancements:
- Rename the Hyundai Kona 2022 platform to '2022-23'
- Switch Hyundai Kona platform from ALT_LIMITS_2 to ALT_LIMITS flag