### PR TITLE
Hyundai CAN: Non-SCC platform support prerequisite

### DIFF
--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -179,6 +179,12 @@ class CarInterface(CarInterfaceBase):
     if stock_cp.flags & HyundaiFlags.ALT_LIMITS_2:
       stock_cp.dashcamOnly = False
 
+    if ret.flags & HyundaiFlagsSP.NON_SCC:
+      stock_cp.alphaLongitudinalAvailable = False
+      stock_cp.openpilotLongitudinalControl = False
+      stock_cp.pcmCruise = True
+      ret.safetyParam |= HyundaiSafetyFlagsSP.NON_SCC
+
     return ret
 
   @staticmethod

--- a/opendbc/car/hyundai/tests/test_hyundai.py
+++ b/opendbc/car/hyundai/tests/test_hyundai.py
@@ -11,7 +11,8 @@ from opendbc.car.hyundai.radar_interface import RADAR_START_ADDR
 from opendbc.car.hyundai.values import CAMERA_SCC_CAR, CANFD_CAR, CAN_GEARS, CAR, CHECKSUM, DATE_FW_ECUS, \
                                          HYBRID_CAR, EV_CAR, FW_QUERY_CONFIG, LEGACY_SAFETY_MODE_CAR, CANFD_FUZZY_WHITELIST, \
                                          UNSUPPORTED_LONGITUDINAL_CAR, PLATFORM_CODE_ECUS, HYUNDAI_VERSION_REQUEST_LONG, \
-                                         HyundaiFlags, get_platform_codes, HyundaiSafetyFlags
+                                         HyundaiFlags, get_platform_codes, HyundaiSafetyFlags, \
+                                         NON_SCC_CAR
 from opendbc.car.hyundai.fingerprints import FW_VERSIONS
 
 Ecu = CarParams.Ecu
@@ -157,6 +158,8 @@ class TestHyundaiFingerprint:
             continue
           if platform_code_ecu == Ecu.eps and car_model in no_eps_platforms:
             continue
+          if car_model in NON_SCC_CAR:
+            continue
           assert platform_code_ecu in [e[0] for e in ecus]
 
   def test_fw_format(self, subtests):
@@ -169,6 +172,9 @@ class TestHyundaiFingerprint:
       with subtests.test(car_model=car_model.value):
         for ecu, fws in ecus.items():
           if ecu[0] not in PLATFORM_CODE_ECUS:
+            continue
+
+          if car_model in NON_SCC_CAR:
             continue
 
           codes = set()
@@ -236,6 +242,9 @@ class TestHyundaiFingerprint:
         for fw in fw_versions:
           car_fw.append(CarParams.CarFw(ecu=ecu_name, fwVersion=fw, address=addr,
                                         subAddress=0 if sub_addr is None else sub_addr))
+
+      if platform in NON_SCC_CAR:
+        continue
 
       CP = CarParams(carFw=car_fw)
       matches = FW_QUERY_CONFIG.match_fw_to_car_fuzzy(build_fw_dict(CP.carFw), CP.carVin, FW_VERSIONS)

--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -8,6 +8,8 @@ from opendbc.car.structs import CarParams
 from opendbc.car.docs_definitions import CarFootnote, CarHarness, CarDocs, CarParts, Column, Device
 from opendbc.car.fw_query_definitions import FwQueryConfig, Request, p16
 
+from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
+
 Ecu = CarParams.Ecu
 
 
@@ -802,5 +804,8 @@ LEGACY_SAFETY_MODE_CAR = CAR.with_flags(HyundaiFlags.LEGACY)
 # TODO: another PR with (HyundaiFlags.LEGACY | HyundaiFlags.UNSUPPORTED_LONGITUDINAL | HyundaiFlags.CAMERA_SCC |
 #       HyundaiFlags.CANFD_RADAR_SCC | HyundaiFlags.CANFD_NO_RADAR_DISABLE | )
 UNSUPPORTED_LONGITUDINAL_CAR = CAR.with_flags(HyundaiFlags.LEGACY) | CAR.with_flags(HyundaiFlags.UNSUPPORTED_LONGITUDINAL)
+
+# port extensions
+NON_SCC_CAR = CAR.with_sp_flags(HyundaiFlagsSP.NON_SCC)
 
 DBC = CAR.create_dbc_map()

--- a/opendbc/sunnypilot/car/hyundai/carstate_ext.py
+++ b/opendbc/sunnypilot/car/hyundai/carstate_ext.py
@@ -9,18 +9,37 @@ from enum import StrEnum
 
 from opendbc.car import Bus, structs
 from opendbc.can.parser import CANParser
+from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 
 
 class CarStateExt:
-  def __init__(self):
-    super().__init__()
+  def __init__(self, CP, CP_SP):
+    self.CP = CP
+    self.CP_SP = CP_SP
 
     self.aBasis = 0.0
 
-  def update(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser]) -> None:
+  def update(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser], speed_conv: float) -> None:
     cp = can_parsers[Bus.pt]
+    cp_cam = can_parsers[Bus.cam]
 
     self.aBasis = cp.vl["TCS13"]["aBasis"]
+
+    if self.CP_SP.flags & HyundaiFlagsSP.NON_SCC:
+      ret.cruiseState.available = False
+      ret.cruiseState.enabled = False
+      ret.cruiseState.speed = 255
+      ret.cruiseState.standstill = False
+      ret.cruiseState.nonAdaptive = False
+
+      if not self.CP_SP.flags & HyundaiFlagsSP.NON_SCC_NO_FCA:
+        cp_cruise = cp if self.CP_SP.flags & HyundaiFlagsSP.NON_SCC_RADAR_FCA else cp_cam
+
+        aeb_src = "FCA11"
+        aeb_warning = cp_cruise.vl[aeb_src]["CF_VSM_Warn"] != 0
+        aeb_braking = cp_cruise.vl[aeb_src]["CF_VSM_DecCmdAct"] != 0 or cp_cruise.vl[aeb_src]["FCA_CmdAct"] != 0
+        ret.stockFcw = aeb_warning and not aeb_braking
+        ret.stockAeb = aeb_warning and aeb_braking
 
   def update_canfd_ext(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser]) -> None:
     cp = can_parsers[Bus.pt]

--- a/opendbc/sunnypilot/car/hyundai/values.py
+++ b/opendbc/sunnypilot/car/hyundai/values.py
@@ -13,6 +13,7 @@ class HyundaiSafetyFlagsSP:
   ESCC = 1
   LONG_MAIN_CRUISE_TOGGLEABLE = 2
   HAS_LDA_BUTTON = 4
+  NON_SCC = 8
 
 
 class HyundaiFlagsSP(IntFlag):
@@ -25,3 +26,6 @@ class HyundaiFlagsSP(IntFlag):
   ENABLE_RADAR_TRACKS_DEPRECATED = 2 ** 3
   LONG_TUNING_DYNAMIC = 2 ** 4
   LONG_TUNING_PREDICTIVE = 2 ** 5
+  NON_SCC = 2 ** 6
+  NON_SCC_RADAR_FCA = 2 ** 7  # most with FCA come from the camera
+  NON_SCC_NO_FCA = 2 ** 8  # not all have FCA


### PR DESCRIPTION
## Summary by Sourcery

Add baseline support for Hyundai platforms without Smart Cruise Control (SCC) by introducing NON_SCC feature flags, disabling cruise and openpilot longitudinal control, and preserving stock AEB/FCW behavior from appropriate CAN sources. Update CarState, CarStateExt, and interface logic to honor non-SCC cases, and adjust existing tests and values definitions accordingly.

New Features:
- Define NON_SCC, NON_SCC_RADAR_FCA, and NON_SCC_NO_FCA flags in HyundaiFlagsSP and HyundaiSafetyFlagsSP
- Introduce NON_SCC_CAR in car/hyundai/values to classify non-SCC platforms

Enhancements:
- Disable cruise availability and openpilot longitudinal control for NON_SCC platforms in CarStateExt and interface logic
- Extract stock forward collision and warning signals from CAM or PT bus based on NON_SCC radar usage
- Propagate CP_SP flags and speed conversion into CarStateExt update routine

Tests:
- Exclude NON_SCC_CAR models from Hyundai platform code, firmware format, and fuzzy matching tests