### PR TITLE
Hyundai angle steering: hugging no more - use the true steering angle signal from MDPS

### DIFF
--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -253,7 +253,7 @@ class CarState(CarStateBase, EsccCarStateBase, MadsCarState, CarStateExt):
                      cp.vl["WHEEL_SPEEDS"]["WHL_SpdRLVal"] <= STANDSTILL_THRESHOLD and cp.vl["WHEEL_SPEEDS"]["WHL_SpdRRVal"] <= STANDSTILL_THRESHOLD
 
     ret.steeringRateDeg = cp.vl["STEERING_SENSORS"]["STEERING_RATE"]
-    ret.steeringAngleDeg = cp.vl["STEERING_SENSORS"]["STEERING_ANGLE"]
+    ret.steeringAngleDeg = cp.vl["MDPS"]["STEERING_ANGLE"]
     ret.steeringTorque = cp.vl["MDPS"]["STEERING_COL_TORQUE"]
     ret.steeringTorqueEps = cp.vl["MDPS"]["STEERING_OUT_TORQUE"]
     ret.steerFaultTemporary = cp.vl["MDPS"]["LKA_FAULT"] != 0

--- a/opendbc/safety/modes/hyundai_canfd.h
+++ b/opendbc/safety/modes/hyundai_canfd.h
@@ -32,7 +32,6 @@
   {.msg = {{0x175, (pt_bus), 24, 50U, .max_counter = 0xffU, .ignore_quality_flag = true}, { 0 }, { 0 }}},  \
   {.msg = {{0xa0, (pt_bus), 24, 100U, .max_counter = 0xffU, .ignore_quality_flag = true}, { 0 }, { 0 }}},  \
   {.msg = {{0xea, (pt_bus), 24, 100U, .max_counter = 0xffU, .ignore_quality_flag = true}, { 0 }, { 0 }}},  \
-  {.msg = {{0x125, (pt_bus), 16, 100U, .ignore_checksum = true, .max_counter = 0xffU, .ignore_quality_flag = true}, { 0 }, { 0 }}},  \
 
 #define HYUNDAI_CANFD_STD_BUTTONS_RX_CHECKS(pt_bus)                                                                                            \
   HYUNDAI_CANFD_COMMON_RX_CHECKS(pt_bus)                                                                                                       \
@@ -80,11 +79,8 @@ static void hyundai_canfd_rx_hook(const CANPacket_t *msg) {
       int torque_driver_new = ((msg->data[11] & 0x1fU) << 8U) | msg->data[10];
       torque_driver_new -= 4095;
       update_sample(&torque_driver, torque_driver_new);
-    }
 
-    // steering angle
-    if (msg->addr == 0x125U) {
-      int angle_meas_new = (msg->data[4] << 8) | msg->data[3];
+      int angle_meas_new = (msg->data[13] << 8) | msg->data[12];
       angle_meas_new = to_signed(angle_meas_new, 16);
       update_sample(&angle_meas, angle_meas_new);
     }

--- a/opendbc/safety/tests/test_hyundai_canfd.py
+++ b/opendbc/safety/tests/test_hyundai_canfd.py
@@ -186,7 +186,7 @@ class TestHyundaiCanfdAngleSteering(TestHyundaiCanfdBase, common.AngleSteeringSa
 
   def _angle_meas_msg(self, angle: float):
     values = {"STEERING_ANGLE": angle}
-    return self.packer.make_can_msg_panda("STEERING_SENSORS", self.PT_BUS, values)
+    return self.packer.make_can_msg_panda("MDPS", self.PT_BUS, values)
 
   def _get_steer_cmd_angle_max(self, speed):
     baseline_vm = self.get_vm(ANGLE_SAFETY_BASELINE_MODEL)


### PR DESCRIPTION
## Summary by Sourcery

Switch the Hyundai CAN FD steering angle source to the MDPS signal, removing the old STEERING_SENSORS message and updating parsing logic and tests accordingly.

Enhancements:
- Parse steering angle using the MDPS CAN message instead of the STEERING_SENSORS (0x125) message in the safety hook
- Adjust byte offsets when extracting the steering angle from the MDPS message in the safety code
- Update CarState to use MDPS.STEERING_ANGLE for steeringAngleDeg
- Modify existing safety tests to pack and validate MDPS steering angle messages