### PR TITLE
Add missing 2025 IONIQ 5 USA firmware components

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1055,6 +1055,13 @@ FW_VERSIONS = {
     ],
   },
   CAR.HYUNDAI_IONIQ_5: {
+    (Ecu.combinationMeter, 0x7c6, None): [
+      b'\xf1\x00421',
+      b'\xf1\x10',
+    ],
+    (Ecu.eps, 0x730, None): [
+      b'\xf1\x00NEaPFBL5 1.00 1.00 240813',
+    ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00NE1_ RDR -----      1.00 1.00 99110-GI000         ',
     ],


### PR DESCRIPTION
- combinationMeter: 421, 10
- eps: NEaPFBL5 1.00 1.00 240813

Completes 2025 Hyundai IONIQ 5 LTD USA fingerprint support

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
Validation
* Dongle ID: 3c4c9d163c72a81d
* Route: 3c4c9d163c72a81d/00000030--c892e547f0/0

## Summary by Sourcery

Complete fingerprint support for the 2025 Hyundai IONIQ 5 LTD USA by adding missing combination meter and EPS firmware component entries

New Features:
- Add combination meter firmware fingerprint (ID 0x7c6) for the 2025 IONIQ 5 USA

Enhancements:
- Add EPS firmware fingerprint (ID 0x730) for the 2025 IONIQ 5 USA