### PR TITLE
Hyundai Longitudinal: fix params type

### DIFF
--- a/opendbc/sunnypilot/car/interfaces.py
+++ b/opendbc/sunnypilot/car/interfaces.py
@@ -26,13 +26,13 @@ def _initialize_custom_longitudinal_tuning(CI: CarInterfaceBase, CP: structs.Car
 
   # Hyundai Custom Longitudinal Tuning
   if CP.brand == 'hyundai':
-    hyundai_longitudinal_tuning = params_dict["HyundaiLongitudinalTuning"]
+    hyundai_longitudinal_tuning = int(params_dict["HyundaiLongitudinalTuning"])
     if hyundai_longitudinal_tuning == LongitudinalTuningType.DYNAMIC:
       CP_SP.flags |= HyundaiFlagsSP.LONG_TUNING_DYNAMIC.value
     if hyundai_longitudinal_tuning == LongitudinalTuningType.PREDICTIVE:
       CP_SP.flags |= HyundaiFlagsSP.LONG_TUNING_PREDICTIVE.value
 
-  CP_SP = CI.get_longitudinal_tuning_sp(CP, CP_SP)
+  _ = CI.get_longitudinal_tuning_sp(CP, CP_SP)
 
 
 def _initialize_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, can_recv: CanRecvCallable = None, can_send: CanSendCallable = None) -> None:


### PR DESCRIPTION
## Summary by Sourcery

Fix type handling in Hyundai longitudinal tuning and adjust tuning initialization call

Bug Fixes:
- Cast HyundaiLongitudinalTuning parameter to int for correct tuning flag comparisons

Enhancements:
- Invoke get_longitudinal_tuning_sp without reassigning CP_SP to avoid unintended struct replacement