### PR TITLE
Update EV9 steerRatio to more accurate value

### DIFF
--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -612,7 +612,7 @@ class CAR(Platforms):
     [
       HyundaiCarDocs("Kia EV9 2025-26", car_parts=CarParts.common([CarHarness.hyundai_r]))
     ],
-    CarSpecs(mass=2664, wheelbase=3.1, steerRatio=16),
+    CarSpecs(mass=2664, wheelbase=3.1, steerRatio=18.66),
     flags=HyundaiFlags.EV | HyundaiFlags.CANFD_ANGLE_STEERING,
   )
   KIA_CARNIVAL_4TH_GEN = HyundaiCanFDPlatformConfig(


### PR DESCRIPTION
<img width="660" height="1434" alt="IMG_9270" src="https://github.com/user-attachments/assets/86f0d0cc-7ab1-486d-8005-87bd9b5d8df9" />

## Summary by Sourcery

Enhancements:
- Update steer ratio for 2025-26 Kia EV9 from 16 to 18.66 in Hyundai car specs