### PR TITLE
Honda: int flag for modified EPS configs

### DIFF
--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -247,15 +247,13 @@ class CarInterface(CarInterfaceBase):
   @staticmethod
   def _get_params_sp(stock_cp: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
                      car_fw: list[structs.CarParams.CarFw], alpha_long: bool, docs: bool) -> structs.CarParamsSP:
-    eps_modified = False
     for fw in car_fw:
       if fw.ecu == "eps" and b"," in fw.fwVersion:
-        ret.flags |= HondaFlagsSP.EPS_MOD.value
-        eps_modified = True
+        ret.flags |= HondaFlagsSP.EPS_MODIFIED.value
         stock_cp.dashcamOnly = False
 
     if candidate == CAR.HONDA_CIVIC:
-      if eps_modified:
+      if ret.flags & HondaFlagsSP.EPS_MODIFIED:
         # stock request input values:     0x0000, 0x00DE, 0x014D, 0x01EF, 0x0290, 0x0377, 0x0454, 0x0610, 0x06EE
         # stock request output values:    0x0000, 0x0917, 0x0DC5, 0x1017, 0x119F, 0x140B, 0x1680, 0x1680, 0x1680
         # modified request output values: 0x0000, 0x0917, 0x0DC5, 0x1017, 0x119F, 0x140B, 0x1680, 0x2880, 0x3180
@@ -266,11 +264,11 @@ class CarInterface(CarInterfaceBase):
         stock_cp.lateralTuning.pid.kpV, stock_cp.lateralTuning.pid.kiV = [[0.3], [0.1]]
 
     elif candidate == CAR.HONDA_ACCORD:
-      if eps_modified:
+      if ret.flags & HondaFlagsSP.EPS_MODIFIED:
         stock_cp.lateralTuning.pid.kpV, stock_cp.lateralTuning.pid.kiV = [[0.3], [0.09]]
 
     elif candidate == CAR.HONDA_CRV_5G:
-      if eps_modified:
+      if ret.flags & HondaFlagsSP.EPS_MODIFIED:
         # stock request input values:     0x0000, 0x00DB, 0x01BB, 0x0296, 0x0377, 0x0454, 0x0532, 0x0610, 0x067F
         # stock request output values:    0x0000, 0x0500, 0x0A15, 0x0E6D, 0x1100, 0x1200, 0x129A, 0x134D, 0x1400
         # modified request output values: 0x0000, 0x0500, 0x0A15, 0x0E6D, 0x1100, 0x1200, 0x1ACD, 0x239A, 0x2800
@@ -281,7 +279,7 @@ class CarInterface(CarInterfaceBase):
       ret.safetyParam |= HondaSafetyFlagsSP.CLARITY
       stock_cp.autoResumeSng = True
       stock_cp.minEnableSpeed = -1
-      if eps_modified:
+      if ret.flags & HondaFlagsSP.EPS_MODIFIED:
         for fw in car_fw:
           if fw.ecu == "eps" and b"-" not in fw.fwVersion and b"," in fw.fwVersion:
             stock_cp.lateralTuning.pid.kf = 0.00004

--- a/opendbc/sunnypilot/car/honda/values_ext.py
+++ b/opendbc/sunnypilot/car/honda/values_ext.py
@@ -10,7 +10,7 @@ from enum import IntFlag
 
 class HondaFlagsSP(IntFlag):
   CLARITY = 1
-  EPS_MOD = 2
+  EPS_MODIFIED = 2
 
 
 class HondaSafetyFlagsSP:


### PR DESCRIPTION
Delete redundant variable eps_modified

Change flag name of EPS_MOD to EPS_MODIFIED for consistency of deleted variable

Change conditional logic to check if EPS_MODIFIED.value is present in ret.flags, instead of checking value of eps_modified

## Summary by Sourcery

Replace eps_modified variable with a flags-based approach and rename EPS_MOD flag to EPS_MODIFIED

Enhancements:
- Remove redundant eps_modified boolean and its assignments
- Rename HondaFlagsSP.EPS_MOD constant to EPS_MODIFIED
- Update conditional logic to use ret.flags & HondaFlagsSP.EPS_MODIFIED instead of eps_modified