### PR TITLE
MADS safety tests: use `teardown`

### DIFF
--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -266,7 +266,6 @@ class TorqueSteeringSafetyTestBase(PandaSafetyTestBase, abc.ABC):
       max_torque = self._get_max_torque(speed)
       for enabled in [0, 1]:
         for t in range(int(-max_torque * 1.5), int(max_torque * 1.5)):
-          self._mads_states_cleanup()
           self.safety.set_controls_allowed(enabled)
           self._set_prev_torque(t)
           if abs(t) > max_torque or (not enabled and abs(t) > 0):
@@ -543,7 +542,6 @@ class MotorTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
       max_torque = self._get_max_torque(speed)
       for controls_allowed in [True, False]:
         for torque in np.arange(-max_torque - 1000, max_torque + 1000, self.MAX_RATE_UP):
-          self._mads_states_cleanup()
           self.safety.set_controls_allowed(controls_allowed)
           self.safety.set_rt_torque_last(torque)
           self.safety.set_torque_meas(torque, torque)
@@ -767,7 +765,6 @@ class AngleSteeringSafetyTest(VehicleSpeedSafetyTest):
           self._reset_angle_measurement(angle_meas)
 
           for angle_cmd in np.arange(-90, 91, 10):
-            self._mads_states_cleanup()
             self._set_prev_desired_angle(angle_cmd)
 
             # controls_allowed is checked if actuation bit is 1, else the angle must be close to meas (inactive)

--- a/opendbc/safety/tests/hyundai_common.py
+++ b/opendbc/safety/tests/hyundai_common.py
@@ -155,7 +155,6 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
             self.safety.set_safety_hooks(default_safety_mode, default_safety_param)
 
             # Test initial state
-            self._mads_states_cleanup()
             self.safety.set_mads_params(enable_mads, False, False)
 
             self.assertFalse(self.safety.get_acc_main_on())
@@ -173,7 +172,6 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
             for _ in range(10):
               self._rx(self._main_cruise_button_msg(1))
               self.assertFalse(self.safety.get_controls_allowed_lat())
-    self._mads_states_cleanup()
     self.safety.set_current_safety_param_sp(default_safety_param_sp)
 
   def test_acc_main_sync_mismatches_reset(self):
@@ -188,7 +186,6 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
         self.safety.set_current_safety_param_sp(default_safety_param_sp | main_cruise_toggleable_flag)
         self.safety.set_safety_hooks(default_safety_mode, default_safety_param)
 
-        self._mads_states_cleanup()
         self.safety.set_mads_params(enable_mads, False, False)
 
         # Initial state
@@ -208,7 +205,6 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
         self._tx(self._tx_acc_state_msg(False))  # acc_main_on_tx = False
         self.assertFalse(self.safety.get_acc_main_on())
         self.assertEqual(0, self.safety.get_acc_main_on_mismatches())
-    self._mads_states_cleanup()
     self.safety.set_current_safety_param_sp(default_safety_param_sp)
 
   def test_acc_main_sync_mismatch_counter(self):
@@ -223,7 +219,6 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
         self.safety.set_current_safety_param_sp(default_safety_param_sp | main_cruise_toggleable_flag)
         self.safety.set_safety_hooks(default_safety_mode, default_safety_param)
 
-        self._mads_states_cleanup()
         self.safety.set_mads_params(enable_mads, False, False)
         self.safety.set_controls_allowed_lat(True)
 
@@ -251,7 +246,6 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
         # Counter should reset after disengagement
         self._tx(self._tx_acc_state_msg(False))
         self.assertEqual(0, self.safety.get_acc_main_on_mismatches())
-    self._mads_states_cleanup()
     self.safety.set_current_safety_param_sp(default_safety_param_sp)
 
   def test_acc_main_sync_mismatch_recovery(self):
@@ -266,7 +260,6 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
         self.safety.set_current_safety_param_sp(default_safety_param_sp | main_cruise_toggleable_flag)
         self.safety.set_safety_hooks(default_safety_mode, default_safety_param)
 
-        self._mads_states_cleanup()
         self.safety.set_mads_params(enable_mads, False, False)
 
         # Create initial mismatch
@@ -278,7 +271,6 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
         # Sync states
         self._tx(self._tx_acc_state_msg(True))  # Match acc_main_on_tx to acc_main_on
         self.assertEqual(0, self.safety.get_acc_main_on_mismatches())
-    self._mads_states_cleanup()
     self.safety.set_current_safety_param_sp(default_safety_param_sp)
 
   def test_tester_present_allowed(self, ecu_disable: bool = True):

--- a/opendbc/safety/tests/mads_common.py
+++ b/opendbc/safety/tests/mads_common.py
@@ -15,6 +15,14 @@ class MadsSafetyTestBase(unittest.TestCase):
   def _acc_state_msg(self, enabled):
     raise NotImplementedError
 
+  def teardown_method(self):
+    self.safety.set_mads_button_press(-1)
+    self.safety.set_controls_allowed_lat(False)
+    self.safety.set_controls_requested_lat(False)
+    self.safety.set_acc_main_on(False)
+    self.safety.set_mads_params(False, False, False)
+    self.safety.set_heartbeat_engaged_mads(True)
+
   def _mads_states_cleanup(self):
     self.safety.set_mads_button_press(-1)
     self.safety.set_controls_allowed_lat(False)

--- a/opendbc/safety/tests/mads_common.py
+++ b/opendbc/safety/tests/mads_common.py
@@ -15,13 +15,8 @@ class MadsSafetyTestBase(unittest.TestCase):
   def _acc_state_msg(self, enabled):
     raise NotImplementedError
 
-  def teardown_method(self):
-    self.safety.set_mads_button_press(-1)
-    self.safety.set_controls_allowed_lat(False)
-    self.safety.set_controls_requested_lat(False)
-    self.safety.set_acc_main_on(False)
-    self.safety.set_mads_params(False, False, False)
-    self.safety.set_heartbeat_engaged_mads(True)
+  def teardown_method(self, method):
+    self._mads_states_cleanup()
 
   def _mads_states_cleanup(self):
     self.safety.set_mads_button_press(-1)
@@ -180,6 +175,7 @@ class MadsSafetyTestBase(unittest.TestCase):
         for pause_lateral_on_brake in (True, False):
           with self.subTest("pause_lateral_on_brake", pause_lateral_on_brake=pause_lateral_on_brake):
             with self.subTest("mads_button"):
+              self._mads_states_cleanup()  # TODO-SP: split up this test for specific edge cases in clean slates
               self.safety.set_mads_params(enable_mads, False, pause_lateral_on_brake)
 
               # Brake press rising edge

--- a/opendbc/safety/tests/mads_common.py
+++ b/opendbc/safety/tests/mads_common.py
@@ -37,7 +37,6 @@ class MadsSafetyTestBase(unittest.TestCase):
       # If boolean is True, the heartbeat is engaged and should remain engaged, otherwise it should disengage.
       with self.subTest(heartbeat_engaged=boolean, should_remain_engaged=boolean):
         # Setup initial conditions
-        self._mads_states_cleanup()
         self.safety.set_mads_params(True, False, False)  # Enable MADS
         self.safety.set_controls_allowed_lat(True)
         self.assertTrue(self.safety.get_controls_allowed_lat())
@@ -61,147 +60,114 @@ class MadsSafetyTestBase(unittest.TestCase):
     except NotImplementedError as err:
       raise unittest.SkipTest("Skipping test because MADS button is not supported") from err
 
-    try:
-      for enable_mads in (True, False):
-        with self.subTest("enable_mads", mads_enabled=enable_mads):
-          self._mads_states_cleanup()
-          self.safety.set_mads_params(enable_mads, False, False)
-          self.assertEqual(enable_mads, self.safety.get_enable_mads())
+    for enable_mads in (True, False):
+      with self.subTest("enable_mads", mads_enabled=enable_mads):
+        self.safety.set_mads_params(enable_mads, False, False)
+        self.assertEqual(enable_mads, self.safety.get_enable_mads())
 
-          self._rx(self._lkas_button_msg(True))
-          self._rx(self._speed_msg(0))
-          self._rx(self._lkas_button_msg(False))
-          self._rx(self._speed_msg(0))
-          self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
+        self._rx(self._lkas_button_msg(True))
+        self._rx(self._speed_msg(0))
+        self._rx(self._lkas_button_msg(False))
+        self._rx(self._speed_msg(0))
+        self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
 
   def test_enable_control_allowed_with_manual_acc_main_on_state(self):
     try:
       self._acc_state_msg(False)
     except NotImplementedError as err:
-      self._mads_states_cleanup()
       raise unittest.SkipTest("Skipping test because _acc_state_msg is not implemented for this car") from err
 
-    try:
-      for enable_mads in (True, False):
-        with self.subTest("enable_mads", mads_enabled=enable_mads):
-          self._mads_states_cleanup()
-          self.safety.set_mads_params(enable_mads, False, False)
-          self._rx(self._acc_state_msg(True))
-          self._rx(self._speed_msg(0))
-          self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
+    for enable_mads in (True, False):
+      with self.subTest("enable_mads", mads_enabled=enable_mads):
+        self.safety.set_mads_params(enable_mads, False, False)
+        self._rx(self._acc_state_msg(True))
+        self._rx(self._speed_msg(0))
+        self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
 
   def test_enable_control_allowed_with_manual_mads_button_state(self):
-    try:
-      for enable_mads in (True, False):
-        with self.subTest("enable_mads", mads_enabled=enable_mads):
-          for mads_button_press in (-1, 0, 1):
-            with self.subTest("mads_button_press", button_state=mads_button_press):
-              self._mads_states_cleanup()
-              self.safety.set_mads_params(enable_mads, False, False)
+    for enable_mads in (True, False):
+      with self.subTest("enable_mads", mads_enabled=enable_mads):
+        for mads_button_press in (-1, 0, 1):
+          with self.subTest("mads_button_press", button_state=mads_button_press):
+            self.safety.set_mads_params(enable_mads, False, False)
 
-              self.safety.set_mads_button_press(mads_button_press)
-              self._rx(self._speed_msg(0))
-              self.assertEqual(enable_mads and mads_button_press == 1, self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
+            self.safety.set_mads_button_press(mads_button_press)
+            self._rx(self._speed_msg(0))
+            self.assertEqual(enable_mads and mads_button_press == 1, self.safety.get_controls_allowed_lat())
 
   def test_enable_control_allowed_from_acc_main_on(self):
     """Test that lateral controls are allowed when ACC main is enabled and disabled when ACC main is disabled"""
-    try:
-      for enable_mads in (True, False):
-        with self.subTest("enable_mads", mads_enabled=enable_mads):
-          for acc_main_on in (True, False):
-            with self.subTest("initial_acc_main", initial_acc_main=acc_main_on):
-              self._mads_states_cleanup()
-              self.safety.set_mads_params(enable_mads, False, False)
+    for enable_mads in (True, False):
+      with self.subTest("enable_mads", mads_enabled=enable_mads):
+        for acc_main_on in (True, False):
+          with self.subTest("initial_acc_main", initial_acc_main=acc_main_on):
+            self.safety.set_mads_params(enable_mads, False, False)
 
-              # Set initial state
-              self.safety.set_acc_main_on(acc_main_on)
-              self._rx(self._speed_msg(0))
-              expected_lat = enable_mads and acc_main_on
-              self.assertEqual(expected_lat, self.safety.get_controls_allowed_lat(),
-                               f"Expected lat: [{expected_lat}] when acc_main_on goes to [{acc_main_on}]")
+            # Set initial state
+            self.safety.set_acc_main_on(acc_main_on)
+            self._rx(self._speed_msg(0))
+            expected_lat = enable_mads and acc_main_on
+            self.assertEqual(expected_lat, self.safety.get_controls_allowed_lat(),
+                             f"Expected lat: [{expected_lat}] when acc_main_on goes to [{acc_main_on}]")
 
-              # Test transition to opposite state
-              self.safety.set_acc_main_on(not acc_main_on)
-              self._rx(self._speed_msg(0))
-              expected_lat = enable_mads and not acc_main_on
-              self.assertEqual(expected_lat, self.safety.get_controls_allowed_lat(),
-                               f"Expected lat: [{expected_lat}] when acc_main_on goes from [{acc_main_on}] to [{not acc_main_on}]")
+            # Test transition to opposite state
+            self.safety.set_acc_main_on(not acc_main_on)
+            self._rx(self._speed_msg(0))
+            expected_lat = enable_mads and not acc_main_on
+            self.assertEqual(expected_lat, self.safety.get_controls_allowed_lat(),
+                             f"Expected lat: [{expected_lat}] when acc_main_on goes from [{acc_main_on}] to [{not acc_main_on}]")
 
-              # Test transition back to initial state
-              self.safety.set_acc_main_on(acc_main_on)
-              self._rx(self._speed_msg(0))
-              expected_lat = enable_mads and acc_main_on
-              self.assertEqual(expected_lat, self.safety.get_controls_allowed_lat(),
-                               f"Expected lat: [{expected_lat}] when acc_main_on goes from [{not acc_main_on}] to [{acc_main_on}]")
-    finally:
-      self._mads_states_cleanup()
+            # Test transition back to initial state
+            self.safety.set_acc_main_on(acc_main_on)
+            self._rx(self._speed_msg(0))
+            expected_lat = enable_mads and acc_main_on
+            self.assertEqual(expected_lat, self.safety.get_controls_allowed_lat(),
+                             f"Expected lat: [{expected_lat}] when acc_main_on goes from [{not acc_main_on}] to [{acc_main_on}]")
 
   def test_mads_with_acc_main_on(self):
-    try:
-      for enable_mads in (True, False):
-        with self.subTest("enable_mads", mads_enabled=enable_mads):
-          self._mads_states_cleanup()
-          self.safety.set_mads_params(enable_mads, False, False)
+    for enable_mads in (True, False):
+      with self.subTest("enable_mads", mads_enabled=enable_mads):
+        self.safety.set_mads_params(enable_mads, False, False)
 
-          self.safety.set_acc_main_on(True)
-          self._rx(self._speed_msg(0))
-          self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
+        self.safety.set_acc_main_on(True)
+        self._rx(self._speed_msg(0))
+        self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
 
-          self.safety.set_acc_main_on(False)
-          self._rx(self._speed_msg(0))
-          self.assertFalse(self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
+        self.safety.set_acc_main_on(False)
+        self._rx(self._speed_msg(0))
+        self.assertFalse(self.safety.get_controls_allowed_lat())
 
   def test_pause_lateral_on_brake_setup(self):
-    try:
-      for enable_mads in (True, False):
-        with self.subTest("enable_mads", enable_mads=enable_mads):
-          for pause_lateral_on_brake in (True, False):
-            with self.subTest("pause_lateral_on_brake", pause_lateral_on_brake=pause_lateral_on_brake):
-              self._mads_states_cleanup()
-              self.safety.set_mads_params(enable_mads, False, pause_lateral_on_brake)
-              self.assertEqual(enable_mads and pause_lateral_on_brake, self.safety.get_pause_lateral_on_brake())
-    finally:
-      self._mads_states_cleanup()
+    for enable_mads in (True, False):
+      with self.subTest("enable_mads", enable_mads=enable_mads):
+        for pause_lateral_on_brake in (True, False):
+          with self.subTest("pause_lateral_on_brake", pause_lateral_on_brake=pause_lateral_on_brake):
+            self.safety.set_mads_params(enable_mads, False, pause_lateral_on_brake)
+            self.assertEqual(enable_mads and pause_lateral_on_brake, self.safety.get_pause_lateral_on_brake())
 
   def test_pause_lateral_on_brake(self):
-    try:
-      self._mads_states_cleanup()
-      self.safety.set_mads_params(True, False, True)
+    self.safety.set_mads_params(True, False, True)
 
-      self._rx(self._user_brake_msg(False))
-      self.safety.set_controls_requested_lat(True)
-      self.safety.set_controls_allowed_lat(True)
+    self._rx(self._user_brake_msg(False))
+    self.safety.set_controls_requested_lat(True)
+    self.safety.set_controls_allowed_lat(True)
 
-      self._rx(self._user_brake_msg(True))
-      # Test we pause lateral
-      self.assertFalse(self.safety.get_controls_allowed_lat())
-      # Make sure we can re-gain lateral actuation
-      self._rx(self._user_brake_msg(False))
-      self.assertTrue(self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
+    self._rx(self._user_brake_msg(True))
+    # Test we pause lateral
+    self.assertFalse(self.safety.get_controls_allowed_lat())
+    # Make sure we can re-gain lateral actuation
+    self._rx(self._user_brake_msg(False))
+    self.assertTrue(self.safety.get_controls_allowed_lat())
 
   def test_no_pause_lateral_on_brake(self):
-    try:
-      self._mads_states_cleanup()
-      self.safety.set_mads_params(True, False, False)
+    self.safety.set_mads_params(True, False, False)
 
-      self._rx(self._user_brake_msg(False))
-      self.safety.set_controls_requested_lat(True)
-      self.safety.set_controls_allowed_lat(True)
+    self._rx(self._user_brake_msg(False))
+    self.safety.set_controls_requested_lat(True)
+    self.safety.set_controls_allowed_lat(True)
 
-      self._rx(self._user_brake_msg(True))
-      self.assertTrue(self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
+    self._rx(self._user_brake_msg(True))
+    self.assertTrue(self.safety.get_controls_allowed_lat())
 
   def test_engage_with_brake_pressed(self):
     try:
@@ -209,109 +175,92 @@ class MadsSafetyTestBase(unittest.TestCase):
     except NotImplementedError as err:
       raise unittest.SkipTest("Skipping test because MADS button is not supported") from err
 
-    try:
-      for enable_mads in (True, False):
-        with self.subTest("enable_mads", enable_mads=enable_mads):
-          for pause_lateral_on_brake in (True, False):
-            with self.subTest("pause_lateral_on_brake", pause_lateral_on_brake=pause_lateral_on_brake):
-              with self.subTest("mads_button"):
-                self._mads_states_cleanup()
-                self.safety.set_mads_params(enable_mads, False, pause_lateral_on_brake)
-
-                # Brake press rising edge
-                self._rx(self._user_brake_msg(True))
-                self._rx(self._lkas_button_msg(True))
-                self._rx(self._speed_msg(0))
-                self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
-
-                # Continuous braking after the first frame of brake press rising edge
-                self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
-                for _ in range(400):
-                  self._rx(self._user_brake_msg(True))
-                  self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
-
-              with self.subTest("acc_main_on"):
-                self._mads_states_cleanup()
-                self.safety.set_mads_params(enable_mads, False, pause_lateral_on_brake)
-
-                # Brake press rising edge
-                self._rx(self._user_brake_msg(True))
-                self.safety.set_acc_main_on(True)
-                self._rx(self._speed_msg(0))
-                self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
-
-                # Continuous braking after the first frame of brake press rising edge
-                self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
-                for _ in range(400):
-                  self._rx(self._user_brake_msg(True))
-                  self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
-
-  def test_pause_lateral_on_brake_with_pressed_and_released(self):
-    try:
-      for enable_mads in (True, False):
-        with self.subTest("enable_mads", enable_mads=enable_mads):
-          for pause_lateral_on_brake in (True, False):
-            with self.subTest("pause_lateral_on_brake", pause_lateral_on_brake=pause_lateral_on_brake):
-              self._mads_states_cleanup()
+    for enable_mads in (True, False):
+      with self.subTest("enable_mads", enable_mads=enable_mads):
+        for pause_lateral_on_brake in (True, False):
+          with self.subTest("pause_lateral_on_brake", pause_lateral_on_brake=pause_lateral_on_brake):
+            with self.subTest("mads_button"):
               self.safety.set_mads_params(enable_mads, False, pause_lateral_on_brake)
 
-              # Set controls_allowed_lat rising edge
-              self.safety.set_controls_requested_lat(True)
-              self._rx(self._speed_msg(0))
-              self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
-
-              # User brake press, validate controls_allowed_lat is false
+              # Brake press rising edge
               self._rx(self._user_brake_msg(True))
+              self._rx(self._lkas_button_msg(True))
               self._rx(self._speed_msg(0))
               self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
 
-              # User brake release, validate controls_allowed_lat is true
-              self._rx(self._user_brake_msg(False))
+              # Continuous braking after the first frame of brake press rising edge
+              self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
+              for _ in range(400):
+                self._rx(self._user_brake_msg(True))
+                self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
+
+            with self.subTest("acc_main_on"):
+              self.safety.set_mads_params(enable_mads, False, pause_lateral_on_brake)
+
+              # Brake press rising edge
+              self._rx(self._user_brake_msg(True))
+              self.safety.set_acc_main_on(True)
               self._rx(self._speed_msg(0))
-              self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
+              self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
+
+              # Continuous braking after the first frame of brake press rising edge
+              self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
+              for _ in range(400):
+                self._rx(self._user_brake_msg(True))
+                self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
+
+  def test_pause_lateral_on_brake_with_pressed_and_released(self):
+    for enable_mads in (True, False):
+      with self.subTest("enable_mads", enable_mads=enable_mads):
+        for pause_lateral_on_brake in (True, False):
+          with self.subTest("pause_lateral_on_brake", pause_lateral_on_brake=pause_lateral_on_brake):
+            self.safety.set_mads_params(enable_mads, False, pause_lateral_on_brake)
+
+            # Set controls_allowed_lat rising edge
+            self.safety.set_controls_requested_lat(True)
+            self._rx(self._speed_msg(0))
+            self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
+
+            # User brake press, validate controls_allowed_lat is false
+            self._rx(self._user_brake_msg(True))
+            self._rx(self._speed_msg(0))
+            self.assertEqual(enable_mads and not pause_lateral_on_brake, self.safety.get_controls_allowed_lat())
+
+            # User brake release, validate controls_allowed_lat is true
+            self._rx(self._user_brake_msg(False))
+            self._rx(self._speed_msg(0))
+            self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
 
   def test_pause_lateral_on_brake_persistent_control_allowed_off(self):
-    try:
-      self._mads_states_cleanup()
-      self.safety.set_mads_params(True, False, True)
+    self.safety.set_mads_params(True, False, True)
 
-      self.safety.set_controls_requested_lat(True)
+    self.safety.set_controls_requested_lat(True)
 
-      # Vehicle moving, validate controls_allowed_lat is true
-      for _ in range(10):
-        self._rx(self._speed_msg(10))
-        self.assertTrue(self.safety.get_controls_allowed_lat())
+    # Vehicle moving, validate controls_allowed_lat is true
+    for _ in range(10):
+      self._rx(self._speed_msg(10))
+      self.assertTrue(self.safety.get_controls_allowed_lat())
 
-      # User braked, vehicle slowed down in 10 frames, then stopped for 10 frames
-      # Validate controls_allowed_lat is false
-      self._rx(self._user_brake_msg(True))
-      for _ in range(10):
-        self._rx(self._speed_msg(5))
-        self.assertFalse(self.safety.get_controls_allowed_lat())
-      for _ in range(10):
-        self._rx(self._speed_msg(0))
-        self.assertFalse(self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
+    # User braked, vehicle slowed down in 10 frames, then stopped for 10 frames
+    # Validate controls_allowed_lat is false
+    self._rx(self._user_brake_msg(True))
+    for _ in range(10):
+      self._rx(self._speed_msg(5))
+      self.assertFalse(self.safety.get_controls_allowed_lat())
+    for _ in range(10):
+      self._rx(self._speed_msg(0))
+      self.assertFalse(self.safety.get_controls_allowed_lat())
 
   def test_enable_lateral_control_with_controls_allowed_rising_edge(self):
-    try:
-      for enable_mads in (True, False):
-        with self.subTest("enable_mads", enable_mads=enable_mads):
-          self._mads_states_cleanup()
-          self.safety.set_mads_params(enable_mads, False, False)
+    for enable_mads in (True, False):
+      with self.subTest("enable_mads", enable_mads=enable_mads):
+        self.safety.set_mads_params(enable_mads, False, False)
 
-          self.safety.set_controls_allowed(False)
-          self._rx(self._speed_msg(0))
-          self.safety.set_controls_allowed(True)
-          self._rx(self._speed_msg(0))
-          self.assertTrue(self.safety.get_controls_allowed())
-    finally:
-      self._mads_states_cleanup()
+        self.safety.set_controls_allowed(False)
+        self._rx(self._speed_msg(0))
+        self.safety.set_controls_allowed(True)
+        self._rx(self._speed_msg(0))
+        self.assertTrue(self.safety.get_controls_allowed())
 
   def test_enable_control_allowed_with_mads_button_and_disable_with_main_cruise(self):
     """Tests main cruise and MADS button state transitions.
@@ -332,27 +281,23 @@ class MadsSafetyTestBase(unittest.TestCase):
     except NotImplementedError as err:
       raise unittest.SkipTest("Skipping test because _acc_state_msg is not implemented for this car") from err
 
-    try:
-      for enable_mads in (True, False):
-        with self.subTest("enable_mads", enable_mads=enable_mads):
-          self._mads_states_cleanup()
-          self.safety.set_mads_params(enable_mads, False, False)
+    for enable_mads in (True, False):
+      with self.subTest("enable_mads", enable_mads=enable_mads):
+        self.safety.set_mads_params(enable_mads, False, False)
 
-          self._rx(self._lkas_button_msg(True))
-          self._rx(self._speed_msg(0))
-          self._rx(self._lkas_button_msg(False))
-          self._rx(self._speed_msg(0))
-          self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
+        self._rx(self._lkas_button_msg(True))
+        self._rx(self._speed_msg(0))
+        self._rx(self._lkas_button_msg(False))
+        self._rx(self._speed_msg(0))
+        self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
 
-          self._rx(self._acc_state_msg(True))
-          self._rx(self._speed_msg(0))
-          self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
+        self._rx(self._acc_state_msg(True))
+        self._rx(self._speed_msg(0))
+        self.assertEqual(enable_mads, self.safety.get_controls_allowed_lat())
 
-          self._rx(self._acc_state_msg(False))
-          self._rx(self._speed_msg(0))
-          self.assertFalse(self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
+        self._rx(self._acc_state_msg(False))
+        self._rx(self._speed_msg(0))
+        self.assertFalse(self.safety.get_controls_allowed_lat())
 
   def test_brake_disengage_with_control_request(self):
     """Tests behavior when controls are requested while brake is engaged
@@ -364,30 +309,25 @@ class MadsSafetyTestBase(unittest.TestCase):
     4. Release brake
     5. Verify controls become allowed
     """
-    try:
-      self._mads_states_cleanup()
-      self.safety.set_mads_params(True, False, True)  # enable MADS with pause lateral on brake
+    self.safety.set_mads_params(True, False, True)  # enable MADS with pause lateral on brake
 
-      # Initial state
-      self.safety.set_controls_allowed_lat(True)
-      self._rx(self._speed_msg(0))
-      self.assertTrue(self.safety.get_controls_allowed_lat())
+    # Initial state
+    self.safety.set_controls_allowed_lat(True)
+    self._rx(self._speed_msg(0))
+    self.assertTrue(self.safety.get_controls_allowed_lat())
 
-      # Brake press disengages lateral
-      self._rx(self._user_brake_msg(True))
-      self.assertFalse(self.safety.get_controls_allowed_lat())
+    # Brake press disengages lateral
+    self._rx(self._user_brake_msg(True))
+    self.assertFalse(self.safety.get_controls_allowed_lat())
 
-      # Request controls while braking
-      self.safety.set_controls_requested_lat(True)
-      self.assertFalse(self.safety.get_controls_allowed_lat())
+    # Request controls while braking
+    self.safety.set_controls_requested_lat(True)
+    self.assertFalse(self.safety.get_controls_allowed_lat())
 
-      # Release brake - should enable since controls were requested
-      self._rx(self._user_brake_msg(False))
-      self._rx(self._speed_msg(0))
-      self.assertTrue(self.safety.get_controls_allowed_lat())
-
-    finally:
-      self._mads_states_cleanup()
+    # Release brake - should enable since controls were requested
+    self._rx(self._user_brake_msg(False))
+    self._rx(self._speed_msg(0))
+    self.assertTrue(self.safety.get_controls_allowed_lat())
 
   def test_brake_disengage_with_acc_main_off(self):
     """Tests behavior when ACC main is turned off while brake is engaged
@@ -399,66 +339,52 @@ class MadsSafetyTestBase(unittest.TestCase):
     4. Release brake
     5. Verify controls remain disengaged
     """
-    try:
-      self._mads_states_cleanup()
-      self.safety.set_mads_params(True, False, True)  # enable MADS with pause lateral on brake
+    self.safety.set_mads_params(True, False, True)  # enable MADS with pause lateral on brake
 
-      # Initial state - enable with ACC main
-      self.safety.set_acc_main_on(True)
-      self._rx(self._speed_msg(0))
-      self.assertTrue(self.safety.get_controls_allowed_lat())
+    # Initial state - enable with ACC main
+    self.safety.set_acc_main_on(True)
+    self._rx(self._speed_msg(0))
+    self.assertTrue(self.safety.get_controls_allowed_lat())
 
-      # Brake press disengages lateral
-      self._rx(self._user_brake_msg(True))
-      self.assertFalse(self.safety.get_controls_allowed_lat())
+    # Brake press disengages lateral
+    self._rx(self._user_brake_msg(True))
+    self.assertFalse(self.safety.get_controls_allowed_lat())
 
-      # Turn ACC main off while braking
-      self.safety.set_acc_main_on(False)
-      self._rx(self._speed_msg(0))
-      self.assertFalse(self.safety.get_controls_allowed_lat())
+    # Turn ACC main off while braking
+    self.safety.set_acc_main_on(False)
+    self._rx(self._speed_msg(0))
+    self.assertFalse(self.safety.get_controls_allowed_lat())
 
-      # Release brake - should remain disabled since ACC main is off
-      self._rx(self._user_brake_msg(False))
-      self._rx(self._speed_msg(0))
-      self.assertFalse(self.safety.get_controls_allowed_lat())
-
-    finally:
-      self._mads_states_cleanup()
+    # Release brake - should remain disabled since ACC main is off
+    self._rx(self._user_brake_msg(False))
+    self._rx(self._speed_msg(0))
+    self.assertFalse(self.safety.get_controls_allowed_lat())
 
   def test_steering_disengage_with_control_request(self):
-    try:
-      self._mads_states_cleanup()
-      self.safety.set_mads_params(True, False, False)
+    self.safety.set_mads_params(True, False, False)
+
+    self.safety.set_controls_allowed_lat(True)
+    self._rx(self._speed_msg(0))
+    self.assertTrue(self.safety.get_controls_allowed_lat())
+
+    self.safety.set_steering_disengage(True)
+    self._rx(self._speed_msg(0))
+    self.assertFalse(self.safety.get_controls_allowed_lat())
+
+  def test_disengage_on_brake(self):
+    for disengage_on_brake in (True, False):
+      self.safety.set_mads_params(True, disengage_on_brake, False)
 
       self.safety.set_controls_allowed_lat(True)
       self._rx(self._speed_msg(0))
       self.assertTrue(self.safety.get_controls_allowed_lat())
 
-      self.safety.set_steering_disengage(True)
+      self._rx(self._user_brake_msg(True))
       self._rx(self._speed_msg(0))
-      self.assertFalse(self.safety.get_controls_allowed_lat())
+      self.assertEqual(not disengage_on_brake, self.safety.get_controls_allowed_lat())
 
-    finally:
-      self._mads_states_cleanup()
-
-  def test_disengage_on_brake(self):
-    try:
-      for disengage_on_brake in (True, False):
-        self._mads_states_cleanup()
-        self.safety.set_mads_params(True, disengage_on_brake, False)
-
-        self.safety.set_controls_allowed_lat(True)
-        self._rx(self._speed_msg(0))
-        self.assertTrue(self.safety.get_controls_allowed_lat())
-
-        self._rx(self._user_brake_msg(True))
-        self._rx(self._speed_msg(0))
-        self.assertEqual(not disengage_on_brake, self.safety.get_controls_allowed_lat())
-
-        self._rx(self._user_brake_msg(False))
-        self._rx(self._speed_msg(0))
-        self.assertEqual(not disengage_on_brake, self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
+      self._rx(self._user_brake_msg(False))
+      self._rx(self._speed_msg(0))
+      self.assertEqual(not disengage_on_brake, self.safety.get_controls_allowed_lat())
 
   # TODO-SP: controls_allowed and controls_allowed_lat check for steering safety tests

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -273,7 +273,6 @@ class TestFordSafetyBase(common.PandaCarSafetyTest):
             for path_angle in path_angles:
               for curvature_rate in curvature_rates:
                 for curvature in curvatures:
-                  self._mads_states_cleanup()
                   self.safety.set_controls_allowed(controls_allowed)
                   self._set_prev_desired_angle(curvature)
                   self._reset_curvature_measurement(curvature, speed)
@@ -380,17 +379,13 @@ class TestFordSafetyBase(common.PandaCarSafetyTest):
         self.assertEqual(enabled, self._tx(self._acc_button_msg(Buttons.CANCEL, bus)))
 
   def test_enable_control_allowed_from_acc_main_on(self):
-    try:
-      for enable_mads in (True, False):
-        with self.subTest("enable_mads", mads_enabled=enable_mads):
-          for main_button_msg_valid in (True, False):
-            with self.subTest("main_button_msg_valid", state_valid=main_button_msg_valid):
-              self._mads_states_cleanup()
-              self.safety.set_mads_params(enable_mads, False, False)
-              self._rx(self._pcm_status_msg(main_button_msg_valid))
-              self.assertEqual(enable_mads and main_button_msg_valid, self.safety.get_controls_allowed_lat())
-    finally:
-      self._mads_states_cleanup()
+    for enable_mads in (True, False):
+      with self.subTest("enable_mads", mads_enabled=enable_mads):
+        for main_button_msg_valid in (True, False):
+          with self.subTest("main_button_msg_valid", state_valid=main_button_msg_valid):
+            self.safety.set_mads_params(enable_mads, False, False)
+            self._rx(self._pcm_status_msg(main_button_msg_valid))
+            self.assertEqual(enable_mads and main_button_msg_valid, self.safety.get_controls_allowed_lat())
 
 
 class TestFordCANFDStockSafety(TestFordSafetyBase):

--- a/opendbc/safety/tests/test_hyundai.py
+++ b/opendbc/safety/tests/test_hyundai.py
@@ -193,7 +193,6 @@ class TestHyundaiSafety(HyundaiButtonBase, common.PandaCarSafetyTest, common.Dri
               self.safety.set_current_safety_param_sp(has_lda_button)
               self.safety.set_safety_hooks(default_safety_mode, default_safety_param)
 
-              self._mads_states_cleanup()
               self.safety.set_mads_params(enable_mads, False, False)
               self.assertEqual(enable_mads, self.safety.get_enable_mads())
 
@@ -203,7 +202,6 @@ class TestHyundaiSafety(HyundaiButtonBase, common.PandaCarSafetyTest, common.Dri
               self._rx(self._speed_msg(0))
               self.assertEqual(enable_mads and has_lda_button_param, self.safety.get_controls_allowed_lat())
     finally:
-      self._mads_states_cleanup()
       self.safety.set_current_safety_param_sp(default_safety_param_sp)
 
 

--- a/opendbc/safety/tests/test_subaru.py
+++ b/opendbc/safety/tests/test_subaru.py
@@ -120,13 +120,11 @@ class TestSubaruSafetyBase(common.PandaCarSafetyTest):
       with self.subTest("enable_mads", mads_enabled=enable_mads):
         for mads_button_press in range(4):
           with self.subTest("mads_button_press", button_state=mads_button_press):
-            self._mads_states_cleanup()
             self.safety.set_mads_params(enable_mads, False, False)
 
             self._rx(self._lkas_button_msg(False, mads_button_press))
             self.assertEqual(enable_mads and mads_button_press in range(1, 4),
                              self.safety.get_controls_allowed_lat())
-    self._mads_states_cleanup()
 
 
 class TestSubaruStockLongitudinalSafetyBase(TestSubaruSafetyBase):

--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -273,7 +273,6 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
     lkas_msg_cam = self._angle_cmd_msg(0, state=self.steer_control_types['LANE_KEEP_ASSIST'], bus=2)
 
     for enable_mads in (True, False):
-      self._mads_states_cleanup()
       self.safety.set_mads_params(enable_mads, True, False)
       # stock system sends no LKAS -> no forwarding, and OP is allowed to TX
       self.assertEqual(1, self._rx(no_lkas_msg_cam))

--- a/opendbc/safety/tests/test_toyota.py
+++ b/opendbc/safety/tests/test_toyota.py
@@ -112,7 +112,6 @@ class TestToyotaSafetyBase(common.PandaCarSafetyTest, common.LongitudinalAccelSa
                                                                   [0, 1], [0, 1],
                                                                   [0, 50, 100],
                                                                   np.linspace(-20, 20, 5)):
-      self._mads_states_cleanup()
       self.safety.set_controls_allowed(engaged)
 
       should_tx = not req and not req2 and angle == 0 and torque_wind_down == 0
@@ -211,7 +210,6 @@ class TestToyotaSafetyAngle(TestToyotaSafetyBase, common.AngleSteeringSafetyTest
     """
     for controls_allowed in (True, False):
       for angle in np.arange(-90, 90, 1):
-        self._mads_states_cleanup()
         self.safety.set_controls_allowed(controls_allowed)
         self._reset_angle_measurement(angle)
         self._set_prev_desired_angle(angle)


### PR DESCRIPTION
Thanks to @adeebshihadeh 's idea to use `teardown` for MADS states reset between tests.