### PR TITLE
bugfix: param store to support the latest param changes

### DIFF
--- a/opendbc/car/structs.py
+++ b/opendbc/car/structs.py
@@ -129,7 +129,7 @@ class CarControlSP:
     type: 'CarControlSP.ParamType' = field(
       default_factory=lambda: CarControlSP.ParamType.string
     )
-  
+
   class ParamType(StrEnum):
     string = auto()
     bool = auto()

--- a/opendbc/car/structs.py
+++ b/opendbc/car/structs.py
@@ -125,7 +125,19 @@ class CarControlSP:
   @auto_dataclass
   class Param:
     key: str = auto_field()
-    value: str = auto_field()
+    value: bytes = auto_field()
+    type: 'CarControlSP.ParamType' = field(
+      default_factory=lambda: CarControlSP.ParamType.string
+    )
+  
+  class ParamType(StrEnum):
+    string = auto()
+    bool = auto()
+    int = auto()
+    float = auto()
+    time = auto()
+    json = auto()
+    bytes = auto()
 
 
 @auto_dataclass

--- a/opendbc/sunnypilot/car/__init__.py
+++ b/opendbc/sunnypilot/car/__init__.py
@@ -5,7 +5,57 @@ This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
 from opendbc.car import structs
+import json
+ParamType = structs.CarControlSP.ParamType
 
 
-def get_param(params: list[structs.CarControlSP.Param], key: str, default_key: str = None) -> str | None:
-  return next((p.value for p in params if p.key == key), default_key)
+def get_param_object(params: list[structs.CarControlSP.Param], key: str) -> structs.CarControlSP.Param:
+  return next((param for param in params if param.key == key))
+
+
+def get_param(params: list[structs.CarControlSP.Param], key: str, default_value = None) -> bytes | str | int | float | bool | dict:
+  if (param := get_param_object(params, key)) is None:
+    return default_value
+  
+  param_value = _get_param_as_type(param)
+  if not isinstance(param_value, type(default_value)) and default_value is not None:
+    raise ValueError(f"Param {key} has type {type(param_value)}, but we expected {type(default_value)} based on the default value")
+  
+  return param_value
+
+
+def _get_param_as_type(param: structs.CarControlSP.Param, *, _forced_param_type: ParamType = None) -> bytes | str | int | float | bool | dict:
+  """ 
+  Convert a Param to its value in the right type
+  :param param: The Param to convert.
+  :param  _forced_param_type: (Only for easy sync, will be remove in the future) If given, it will be used instead of the param's own type. 
+  Must be explicitly passed as a keyword argument.
+  :return: 
+  """
+  return _convert_param_to_type(param.value, _forced_param_type or param.type)
+
+
+def _convert_param_to_type(value: bytes, param_type: ParamType) -> bytes | str | int | float | bool | dict:
+  """ 
+  Convert a byte value to the specified param type. Used internally when getting a Param to convert it to the right type.
+  If this method looks familiar, it's because on SP we have a similar one in sunnylink/utils.py.
+  """
+
+  # We convert to string anything that isn't bytes first. We later transform further.
+  if param_type != ParamType.bytes:
+    value = value.decode('utf-8')  # type: ignore
+
+  if param_type == ParamType.string:
+    value = value
+  elif param_type == ParamType.bool:
+    value = value.lower() in ('true', '1', 'yes')  # type: ignore
+  elif param_type == ParamType.int:
+    value = int(value)  # type: ignore
+  elif param_type == ParamType.float:
+    value = float(value)  # type: ignore
+  elif param_type == ParamType.time:
+    value = str(value)  # type: ignore
+  elif param_type == ParamType.json:
+    value = json.loads(value)
+
+  return value

--- a/opendbc/sunnypilot/car/__init__.py
+++ b/opendbc/sunnypilot/car/__init__.py
@@ -9,8 +9,8 @@ import json
 ParamType = structs.CarControlSP.ParamType
 
 
-def get_param_object(params: list[structs.CarControlSP.Param], key: str) -> structs.CarControlSP.Param:
-  return next(param for param in params if param.key == key)
+def get_param_object(params: list[structs.CarControlSP.Param], key: str) -> structs.CarControlSP.Param | None:
+  return next((param for param in params if param.key == key), None)
 
 
 def get_param(params: list[structs.CarControlSP.Param], key: str, default_value = None) -> bytes | str | int | float | bool | dict:

--- a/opendbc/sunnypilot/car/__init__.py
+++ b/opendbc/sunnypilot/car/__init__.py
@@ -10,33 +10,32 @@ ParamType = structs.CarControlSP.ParamType
 
 
 def get_param_object(params: list[structs.CarControlSP.Param], key: str) -> structs.CarControlSP.Param:
-  return next((param for param in params if param.key == key))
+  return next(param for param in params if param.key == key)
 
 
 def get_param(params: list[structs.CarControlSP.Param], key: str, default_value = None) -> bytes | str | int | float | bool | dict:
   if (param := get_param_object(params, key)) is None:
     return default_value
-  
+
   param_value = _get_param_as_type(param)
   if not isinstance(param_value, type(default_value)) and default_value is not None:
     raise ValueError(f"Param {key} has type {type(param_value)}, but we expected {type(default_value)} based on the default value")
-  
+
   return param_value
 
 
 def _get_param_as_type(param: structs.CarControlSP.Param, *, _forced_param_type: ParamType = None) -> bytes | str | int | float | bool | dict:
-  """ 
+  """
   Convert a Param to its value in the right type
   :param param: The Param to convert.
-  :param  _forced_param_type: (Only for easy sync, will be remove in the future) If given, it will be used instead of the param's own type. 
+  :param  _forced_param_type: (Only for easy sync, will be remove in the future) If given, it will be used instead of the param's own type.
   Must be explicitly passed as a keyword argument.
-  :return: 
   """
   return _convert_param_to_type(param.value, _forced_param_type or param.type)
 
 
 def _convert_param_to_type(value: bytes, param_type: ParamType) -> bytes | str | int | float | bool | dict:
-  """ 
+  """
   Convert a byte value to the specified param type. Used internally when getting a Param to convert it to the right type.
   If this method looks familiar, it's because on SP we have a similar one in sunnylink/utils.py.
   """


### PR DESCRIPTION
> [!NOTE]
> * Sister PR: https://github.com/sunnypilot/sunnypilot/pull/1244 

This PR fixes the param store to properly fetch and return data with the new format, and allows the users (in opendbc) to get the param with the actual expected data type.

## Summary by Sourcery

Support the updated parameter format by storing raw bytes with explicit types in the Param struct and providing type-aware retrieval and conversion functions

New Features:
- Introduce ParamType enum and update Param struct to store value as bytes along with its data type
- Add get_param_object and get_param functions to fetch raw Param objects and return values in their native Python types with default-value validation
- Implement internal helpers to convert parameter bytes into Python types (string, bool, int, float, JSON, etc.)

Bug Fixes:
- Fix param store to properly handle the new binary format and return typed data