### PR TITLE
Pin pycapnp to 2.1.0 to prevent a failure on the pipelines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "numpy",
   "crcmod",
   "tqdm",
-  "pycapnp",
+  "pycapnp==2.1.0",
   "pycryptodome",
 ]
 


### PR DESCRIPTION
Duplicates 
* https://github.com/commaai/opendbc/pull/2790 (upstream) 

But this is in case comma takes longer to take the change as we'd like to be able to rely on the tests