### PR TITLE
Fix param store tici

### DIFF
--- a/opendbc/car/structs.py
+++ b/opendbc/car/structs.py
@@ -129,7 +129,7 @@ class CarControlSP:
     type: 'CarControlSP.ParamType' = field(
       default_factory=lambda: CarControlSP.ParamType.string
     )
-  
+
   class ParamType(StrEnum):
     string = auto()
     bool = auto()

--- a/opendbc/car/structs.py
+++ b/opendbc/car/structs.py
@@ -125,7 +125,19 @@ class CarControlSP:
   @auto_dataclass
   class Param:
     key: str = auto_field()
-    value: str = auto_field()
+    value: bytes = auto_field()
+    type: 'CarControlSP.ParamType' = field(
+      default_factory=lambda: CarControlSP.ParamType.string
+    )
+  
+  class ParamType(StrEnum):
+    string = auto()
+    bool = auto()
+    int = auto()
+    float = auto()
+    time = auto()
+    json = auto()
+    bytes = auto()
 
 
 @auto_dataclass

--- a/opendbc/sunnypilot/car/__init__.py
+++ b/opendbc/sunnypilot/car/__init__.py
@@ -5,7 +5,57 @@ This file is part of sunnypilot and is licensed under the MIT License.
 See the LICENSE.md file in the root directory for more details.
 """
 from opendbc.car import structs
+import json
+ParamType = structs.CarControlSP.ParamType
 
 
-def get_param(params: list[structs.CarControlSP.Param], key: str, default_key: str = None) -> str | None:
-  return next((p.value for p in params if p.key == key), default_key)
+def get_param_object(params: list[structs.CarControlSP.Param], key: str) -> structs.CarControlSP.Param:
+  return next((param for param in params if param.key == key))
+
+
+def get_param(params: list[structs.CarControlSP.Param], key: str, default_value = None) -> bytes | str | int | float | bool | dict:
+  if (param := get_param_object(params, key)) is None:
+    return default_value
+  
+  param_value = _get_param_as_type(param)
+  if not isinstance(param_value, type(default_value)) and default_value is not None:
+    raise ValueError(f"Param {key} has type {type(param_value)}, but we expected {type(default_value)} based on the default value")
+  
+  return param_value
+
+
+def _get_param_as_type(param: structs.CarControlSP.Param, *, _forced_param_type: ParamType = None) -> bytes | str | int | float | bool | dict:
+  """ 
+  Convert a Param to its value in the right type
+  :param param: The Param to convert.
+  :param  _forced_param_type: (Only for easy sync, will be remove in the future) If given, it will be used instead of the param's own type. 
+  Must be explicitly passed as a keyword argument.
+  :return: 
+  """
+  return _convert_param_to_type(param.value, _forced_param_type or param.type)
+
+
+def _convert_param_to_type(value: bytes, param_type: ParamType) -> bytes | str | int | float | bool | dict:
+  """ 
+  Convert a byte value to the specified param type. Used internally when getting a Param to convert it to the right type.
+  If this method looks familiar, it's because on SP we have a similar one in sunnylink/utils.py.
+  """
+
+  # We convert to string anything that isn't bytes first. We later transform further.
+  if param_type != ParamType.bytes:
+    value = value.decode('utf-8')  # type: ignore
+
+  if param_type == ParamType.string:
+    value = value
+  elif param_type == ParamType.bool:
+    value = value.lower() in ('true', '1', 'yes')  # type: ignore
+  elif param_type == ParamType.int:
+    value = int(value)  # type: ignore
+  elif param_type == ParamType.float:
+    value = float(value)  # type: ignore
+  elif param_type == ParamType.time:
+    value = str(value)  # type: ignore
+  elif param_type == ParamType.json:
+    value = json.loads(value)
+
+  return value

--- a/opendbc/sunnypilot/car/__init__.py
+++ b/opendbc/sunnypilot/car/__init__.py
@@ -9,8 +9,8 @@ import json
 ParamType = structs.CarControlSP.ParamType
 
 
-def get_param_object(params: list[structs.CarControlSP.Param], key: str) -> structs.CarControlSP.Param:
-  return next(param for param in params if param.key == key)
+def get_param_object(params: list[structs.CarControlSP.Param], key: str) -> structs.CarControlSP.Param | None:
+  return next((param for param in params if param.key == key), None)
 
 
 def get_param(params: list[structs.CarControlSP.Param], key: str, default_value = None) -> bytes | str | int | float | bool | dict:

--- a/opendbc/sunnypilot/car/__init__.py
+++ b/opendbc/sunnypilot/car/__init__.py
@@ -10,33 +10,32 @@ ParamType = structs.CarControlSP.ParamType
 
 
 def get_param_object(params: list[structs.CarControlSP.Param], key: str) -> structs.CarControlSP.Param:
-  return next((param for param in params if param.key == key))
+  return next(param for param in params if param.key == key)
 
 
 def get_param(params: list[structs.CarControlSP.Param], key: str, default_value = None) -> bytes | str | int | float | bool | dict:
   if (param := get_param_object(params, key)) is None:
     return default_value
-  
+
   param_value = _get_param_as_type(param)
   if not isinstance(param_value, type(default_value)) and default_value is not None:
     raise ValueError(f"Param {key} has type {type(param_value)}, but we expected {type(default_value)} based on the default value")
-  
+
   return param_value
 
 
 def _get_param_as_type(param: structs.CarControlSP.Param, *, _forced_param_type: ParamType = None) -> bytes | str | int | float | bool | dict:
-  """ 
+  """
   Convert a Param to its value in the right type
   :param param: The Param to convert.
-  :param  _forced_param_type: (Only for easy sync, will be remove in the future) If given, it will be used instead of the param's own type. 
+  :param  _forced_param_type: (Only for easy sync, will be remove in the future) If given, it will be used instead of the param's own type.
   Must be explicitly passed as a keyword argument.
-  :return: 
   """
   return _convert_param_to_type(param.value, _forced_param_type or param.type)
 
 
 def _convert_param_to_type(value: bytes, param_type: ParamType) -> bytes | str | int | float | bool | dict:
-  """ 
+  """
   Convert a byte value to the specified param type. Used internally when getting a Param to convert it to the right type.
   If this method looks familiar, it's because on SP we have a similar one in sunnylink/utils.py.
   """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "numpy",
   "crcmod",
   "tqdm",
-  "pycapnp",
+  "pycapnp==2.1.0",
   "pycryptodome",
 ]
 


### PR DESCRIPTION
* sister PR: https://github.com/sunnypilot/sunnypilot/pull/1246

## Summary by Sourcery

Provide typed access to CarControlSP parameters by storing values as bytes alongside a ParamType enum and offering get_param utilities with automatic type conversion, and pin the pycapnp dependency to version 2.1.0

New Features:
- Add get_param and get_param_object functions for retrieving typed CarControlSP parameters
- Introduce ParamType enum to support string, bool, int, float, time, json, and bytes parameter types

Enhancements:
- Update CarControlSP.Param to store value as bytes and include an explicit type field
- Implement internal conversion utilities (_get_param_as_type and _convert_param_to_type) for robust type handling

Build:
- Pin pycapnp dependency to version 2.1.0