### PR TITLE
Add fingerprinting values for 2021 Nissan Altima

### DIFF
--- a/opendbc/car/nissan/fingerprints.py
+++ b/opendbc/car/nissan/fingerprints.py
@@ -8,15 +8,19 @@ FW_VERSIONS = {
   CAR.NISSAN_ALTIMA: {
     (Ecu.fwdCamera, 0x707, None): [
       b'284N86CA1D',
+      b'284N89HE1A',
     ],
     (Ecu.eps, 0x742, None): [
       b'6CA2B\xa9A\x02\x02G8A89P90D6A\x00\x00\x01\x80',
+      b'6CA2C\xa9A\x02\x02G8A89P90D6A\x00\x00\x01\x80',
     ],
     (Ecu.engine, 0x7e0, None): [
       b'237109HE2B',
+      b'237109HB2C',
     ],
     (Ecu.gateway, 0x18dad0f1, None): [
       b'284U29HE0A',
+      b'284U29HB0A',
     ],
   },
   CAR.NISSAN_LEAF: {

--- a/opendbc/car/nissan/values.py
+++ b/opendbc/car/nissan/values.py
@@ -75,6 +75,10 @@ class CAR(Platforms):
     [NissanCarDocs("Nissan Altima 2019-20", car_parts=CarParts.common([CarHarness.nissan_b]))],
     NissanCarSpecs(mass=1492, wheelbase=2.824)
   )
+  NISSAN_ALTIMA_21 = NissanPlatformConfig(
+    [NissanCarDocs("Nissan Altima SV 2021", car_parts=CarParts.common([CarHarness.nissan_b]))],
+    NissanCarSpecs(mass=1628, wheelbase=2.824, steerRatio: 17.465)
+  )
 
 
 DBC = CAR.create_dbc_map()


### PR DESCRIPTION
Adding values for fingerprinting 2021 Nissan Altima

## Summary by Sourcery

Enable support for the 2021 Nissan Altima by updating CAN fingerprints and adding a new platform configuration

New Features:
- Add new fingerprint values for fwdCamera, EPS, engine, and gateway ECUs for the 2021 Nissan Altima
- Introduce NISSAN_ALTIMA_21 platform configuration with vehicle specifications and documentation