### PR TITLE
Bring back community (SDSU/Pedal/IPAS) DBC

### DIFF
--- a/opendbc/dbc/generator/gm/gm_global_a_powertrain.dbc
+++ b/opendbc/dbc/generator/gm/gm_global_a_powertrain.dbc
@@ -1,3 +1,4 @@
+CM_ "IMPORT _community.dbc";
 
 VERSION ""
 

--- a/opendbc/dbc/generator/honda/acura_ilx_2016_can.dbc
+++ b/opendbc/dbc/generator/honda/acura_ilx_2016_can.dbc
@@ -1,3 +1,4 @@
+CM_ "IMPORT _community.dbc";
 CM_ "IMPORT _honda_common.dbc";
 CM_ "IMPORT _nidec_common.dbc";
 CM_ "IMPORT _lkas_hud_5byte.dbc";

--- a/opendbc/dbc/generator/honda/acura_rdx_2018_can.dbc
+++ b/opendbc/dbc/generator/honda/acura_rdx_2018_can.dbc
@@ -1,3 +1,4 @@
+CM_ "IMPORT _community.dbc";
 CM_ "IMPORT _honda_common.dbc";
 CM_ "IMPORT _nidec_common.dbc";
 CM_ "IMPORT _lkas_hud_5byte.dbc";

--- a/opendbc/dbc/generator/honda/honda_civic_touring_2016_can.dbc
+++ b/opendbc/dbc/generator/honda/honda_civic_touring_2016_can.dbc
@@ -1,3 +1,4 @@
+CM_ "IMPORT _community.dbc";
 CM_ "IMPORT _honda_common.dbc";
 CM_ "IMPORT _nidec_common.dbc";
 CM_ "IMPORT _lkas_hud_5byte.dbc";

--- a/opendbc/dbc/generator/honda/honda_clarity_hybrid_2018_can.dbc
+++ b/opendbc/dbc/generator/honda/honda_clarity_hybrid_2018_can.dbc
@@ -1,3 +1,4 @@
+CM_ "IMPORT _community.dbc";
 CM_ "IMPORT _honda_common.dbc";
 CM_ "IMPORT _nidec_common.dbc";
 CM_ "IMPORT _lkas_hud_5byte.dbc";

--- a/opendbc/dbc/generator/honda/honda_crv_touring_2016_can.dbc
+++ b/opendbc/dbc/generator/honda/honda_crv_touring_2016_can.dbc
@@ -1,3 +1,4 @@
+CM_ "IMPORT _community.dbc";
 CM_ "IMPORT _honda_common.dbc";
 CM_ "IMPORT _nidec_common.dbc";
 CM_ "IMPORT _lkas_hud_5byte.dbc";

--- a/opendbc/dbc/generator/honda/honda_odyssey_exl_2018.dbc
+++ b/opendbc/dbc/generator/honda/honda_odyssey_exl_2018.dbc
@@ -1,3 +1,4 @@
+CM_ "IMPORT _community.dbc";
 CM_ "IMPORT _honda_common.dbc";
 CM_ "IMPORT _nidec_common.dbc";
 CM_ "IMPORT _lkas_hud_5byte.dbc";

--- a/opendbc/dbc/generator/toyota/toyota_new_mc_pt.dbc
+++ b/opendbc/dbc/generator/toyota/toyota_new_mc_pt.dbc
@@ -1,3 +1,4 @@
+CM_ "IMPORT _community.dbc";
 CM_ "IMPORT _toyota_2017.dbc";
 CM_ "IMPORT _toyota_adas_standard.dbc";
 

--- a/opendbc/dbc/generator/toyota/toyota_nodsu_pt.dbc
+++ b/opendbc/dbc/generator/toyota/toyota_nodsu_pt.dbc
@@ -1,3 +1,4 @@
+CM_ "IMPORT _community.dbc";
 CM_ "IMPORT _toyota_2017.dbc";
 CM_ "IMPORT _toyota_adas_standard.dbc";
 

--- a/opendbc/dbc/generator/toyota/toyota_tnga_k_pt.dbc
+++ b/opendbc/dbc/generator/toyota/toyota_tnga_k_pt.dbc
@@ -1,3 +1,4 @@
+CM_ "IMPORT _community.dbc";
 CM_ "IMPORT _toyota_2017.dbc";
 CM_ "IMPORT _toyota_adas_standard.dbc";
 


### PR DESCRIPTION
## Summary by Sourcery

Reintroduce community-contributed CAN DBC generator files for GM, Honda, and Toyota models

New Features:
- Add SDSU community DBC for GM Global A powertrain
- Add Pedal community DBCs for multiple Honda models (Acura ILX 2016, Acura RDX 2018, Civic Touring 2016, Clarity Hybrid 2018, CR-V Touring 2016, Odyssey EX-L 2018)
- Add IPAS community DBCs for Toyota models (New MC PT, No DSU PT, TNGA K PT)