### PR TITLE
HKG: Remove Kia Forte Non-SCC 2019 from dashcamOnly

### DIFF
--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -186,7 +186,7 @@ class CarInterface(CarInterfaceBase):
       ret.safetyParam |= HyundaiSafetyFlagsSP.NON_SCC
 
     # untested non-SCC platforms, need user validations
-    if stock_cp.carFingerprint in (CAR.HYUNDAI_BAYON_1ST_GEN_NON_SCC, CAR.KIA_FORTE_2019_NON_SCC, CAR.KIA_FORTE_2021_NON_SCC,
+    if stock_cp.carFingerprint in (CAR.HYUNDAI_BAYON_1ST_GEN_NON_SCC, CAR.KIA_FORTE_2021_NON_SCC,
                                    CAR.KIA_SELTOS_2023_NON_SCC, CAR.GENESIS_G70_2021_NON_SCC):
       stock_cp.dashcamOnly = True
 

--- a/opendbc/sunnypilot/car/car_list.json
+++ b/opendbc/sunnypilot/car/car_list.json
@@ -1914,6 +1914,16 @@
     ],
     "package": "Smart Cruise Control (SCC)"
   },
+  "Kia Forte Non-SCC 2019": {
+    "platform": "KIA_FORTE_2019_NON_SCC",
+    "make": "Kia",
+    "brand": "hyundai",
+    "model": "Forte Non-SCC",
+    "year": [
+      "2019"
+    ],
+    "package": "No Smart Cruise Control (Non-SCC)"
+  },
   "Kia K5 2021-24": {
     "platform": "KIA_K5_2021",
     "make": "Kia",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove the Kia Forte 2019 non-SCC fingerprint from the untested non-SCC dashcam-only list