### PR TITLE
Subaru Global Gen2: bump steering limits

### DIFF
--- a/opendbc/car/subaru/values.py
+++ b/opendbc/car/subaru/values.py
@@ -20,9 +20,9 @@ class CarControllerParams:
 
     if CP.flags & SubaruFlags.GLOBAL_GEN2:
       # TODO: lower rate limits, this reaches min/max in 0.5s which negatively affects tuning
-      self.STEER_MAX = 1000
+      self.STEER_MAX = 1600
       self.STEER_DELTA_UP = 40
-      self.STEER_DELTA_DOWN = 40
+      self.STEER_DELTA_DOWN = 55
     elif CP.carFingerprint == CAR.SUBARU_IMPREZA_2020:
       self.STEER_DELTA_UP = 35
       self.STEER_MAX = 1439

--- a/opendbc/safety/modes/subaru.h
+++ b/opendbc/safety/modes/subaru.h
@@ -143,7 +143,7 @@ static void subaru_rx_hook(const CANPacket_t *msg) {
 
 static bool subaru_tx_hook(const CANPacket_t *msg) {
   const TorqueSteeringLimits SUBARU_STEERING_LIMITS      = SUBARU_STEERING_LIMITS_GENERATOR(2047, 50, 70);
-  const TorqueSteeringLimits SUBARU_GEN2_STEERING_LIMITS = SUBARU_STEERING_LIMITS_GENERATOR(1000, 40, 40);
+  const TorqueSteeringLimits SUBARU_GEN2_STEERING_LIMITS = SUBARU_STEERING_LIMITS_GENERATOR(1600, 40, 55);
 
   const LongitudinalLimits SUBARU_LONG_LIMITS = {
     .min_gas = 808,       // appears to be engine braking

--- a/opendbc/safety/tests/test_subaru.py
+++ b/opendbc/safety/tests/test_subaru.py
@@ -197,8 +197,8 @@ class TestSubaruGen2TorqueSafetyBase(TestSubaruTorqueSafetyBase):
   ALT_CAM_BUS = SUBARU_ALT_BUS
 
   MAX_RATE_UP = 40
-  MAX_RATE_DOWN = 40
-  MAX_TORQUE_LOOKUP = [0], [1000]
+  MAX_RATE_DOWN = 55
+  MAX_TORQUE_LOOKUP = [0], [1600]
 
 
 class TestSubaruGen2TorqueStockLongitudinalSafety(TestSubaruStockLongitudinalSafetyBase, TestSubaruGen2TorqueSafetyBase):


### PR DESCRIPTION
- Highest lateral acceleration observed at 55 MPH was ~2.8 m/s^2
- Steer up rate limits: unchanged with around 0.8s
- Steer down rate limits: slightly increased to get close to ~0.58s