### PR TITLE
Hyundai: parse speed limit from various CAN source

### DIFF
--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -205,7 +205,7 @@ class CarState(CarStateBase, EsccCarStateBase, MadsCarState, CarStateExt):
     if self.CP.openpilotLongitudinalControl:
       ret.cruiseState.available = self.get_main_cruise(ret)
 
-    CarStateExt.update(self, ret, can_parsers, speed_conv)
+    CarStateExt.update(self, ret, ret_sp, can_parsers, speed_conv)
 
     ret.blockPcmEnable = not self.recent_button_interaction()
 
@@ -311,7 +311,7 @@ class CarState(CarStateBase, EsccCarStateBase, MadsCarState, CarStateExt):
     if self.CP.openpilotLongitudinalControl:
       ret.cruiseState.available = self.get_main_cruise(ret)
 
-    CarStateExt.update_canfd_ext(self, ret, can_parsers)
+    CarStateExt.update_canfd_ext(self, ret, ret_sp, can_parsers, speed_factor)
 
     ret.blockPcmEnable = not self.recent_button_interaction()
 

--- a/opendbc/sunnypilot/car/hyundai/carstate_ext.py
+++ b/opendbc/sunnypilot/car/hyundai/carstate_ext.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 
 from opendbc.car import Bus, structs
 from opendbc.can.parser import CANParser
-from opendbc.car.hyundai.values import CAR, HyundaiFlags
+from opendbc.car.hyundai.values import HyundaiFlags
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 
 

--- a/opendbc/sunnypilot/car/hyundai/carstate_ext.py
+++ b/opendbc/sunnypilot/car/hyundai/carstate_ext.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 
 from opendbc.car import Bus, structs
 from opendbc.can.parser import CANParser
-from opendbc.car.hyundai.values import HyundaiFlags
+from opendbc.car.hyundai.values import CAR, HyundaiFlags
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 
 
@@ -20,7 +20,28 @@ class CarStateExt:
 
     self.aBasis = 0.0
 
-  def update(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser], speed_conv: float) -> None:
+  def update_speed_limit(self, cp, cp_cam) -> float:
+    speed_limit = 0
+
+    if self.CP.flags & HyundaiFlags.CANFD:
+      if self.CP_SP.flags & HyundaiFlagsSP.SPEED_LIMIT_AVAILABLE:
+        bus = cp if self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING else cp_cam
+        speed_limit = bus.vl["FR_CMR_02_100ms"]["ISLW_SpdCluMainDis"]
+    else:
+      nav, cam = 0, 0
+      if self.CP_SP.flags & HyundaiFlagsSP.SPEED_LIMIT_AVAILABLE:
+        nav = cp.vl["Navi_HU"]["SpeedLim_Nav_Clu"]
+      if self.CP_SP.flags & HyundaiFlagsSP.HAS_LKAS12:
+        cam = cp_cam.vl["LKAS12"]["CF_Lkas_TsrSpeed_Display_Clu"]
+
+      speed_limit = cam if cam not in (0, 255) else nav
+
+    if speed_limit in (0, 255):
+      speed_limit = 0
+
+    return speed_limit
+
+  def update(self, ret: structs.CarState, ret_sp: structs.CarStateSP, can_parsers: dict[StrEnum, CANParser], speed_conv: float) -> None:
     cp = can_parsers[Bus.pt]
     cp_cam = can_parsers[Bus.cam]
 
@@ -53,7 +74,13 @@ class CarStateExt:
         ret.stockFcw = aeb_warning and not aeb_braking
         ret.stockAeb = aeb_warning and aeb_braking
 
-  def update_canfd_ext(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser]) -> None:
+    ret_sp.speedLimit = self.update_speed_limit(cp, cp_cam) * speed_conv
+
+  def update_canfd_ext(self, ret: structs.CarState, ret_sp: structs.CarStateSP, can_parsers: dict[StrEnum, CANParser],
+                       speed_factor: float) -> None:
     cp = can_parsers[Bus.pt]
+    cp_cam = can_parsers[Bus.cam]
 
     self.aBasis = cp.vl["TCS"]["aBasis"]
+
+    ret_sp.speedLimit = self.update_speed_limit(cp, cp_cam) * speed_factor

--- a/opendbc/sunnypilot/car/hyundai/values.py
+++ b/opendbc/sunnypilot/car/hyundai/values.py
@@ -29,3 +29,5 @@ class HyundaiFlagsSP(IntFlag):
   NON_SCC = 2 ** 6
   NON_SCC_RADAR_FCA = 2 ** 7  # most with FCA come from the camera
   NON_SCC_NO_FCA = 2 ** 8  # not all have FCA
+  SPEED_LIMIT_AVAILABLE = 2 ** 9  # platforms with speed limit data available
+  HAS_LKAS12 = 2 ** 10


### PR DESCRIPTION
## Summary by Sourcery

Enable speed limit detection for Hyundai vehicles by parsing from FR_CMR_02_100ms, Navi_HU, and LKAS12 messages, introduce new flags to indicate availability, and extend CarStateExt and interface logic to propagate the speedLimit to CarStateSP.

New Features:
- Parse and expose speed limit from various Hyundai CAN and CAN-FD sources
- Detect and set HAS_LKAS12 flag based on LKAS12 message presence

Enhancements:
- Extend CarStateExt.update and update_canfd_ext to include CarStateSP and assign speedLimit
- Unify CAN bus selection logic for speed limit parsing based on CANFD and camera steering flags
- Adjust carstate update calls to pass CarStateSP and speed factor

Chores:
- Add SPEED_LIMIT_AVAILABLE and HAS_LKAS12 flags in HyundaiFlagsSP