### PR TITLE
Tesla: Parse speed limit from CAN

### DIFF
--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -121,7 +121,7 @@ class CarState(CarStateBase, CarStateExt):
     # Messages needed by carcontroller
     self.das_control = copy.copy(cp_ap_party.vl["DAS_control"])
 
-    CarStateExt.update(self, ret, can_parsers)
+    CarStateExt.update(self, ret, ret_sp, can_parsers)
 
     return ret, ret_sp
 

--- a/opendbc/sunnypilot/car/tesla/carstate_ext.py
+++ b/opendbc/sunnypilot/car/tesla/carstate_ext.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 
 from opendbc.car import Bus, create_button_events, structs
 from opendbc.can.parser import CANParser
+from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.tesla.values import DBC, CANBUS
 from opendbc.sunnypilot.car.tesla.values import TeslaFlagsSP
 
@@ -21,7 +22,7 @@ class CarStateExt:
 
     self.infotainment_3_finger_press = 0
 
-  def update(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser]) -> None:
+  def update(self, ret: structs.CarState, ret_sp: structs.CarStateSP, can_parsers: dict[StrEnum, CANParser]) -> None:
     if self.CP_SP.flags & TeslaFlagsSP.HAS_VEHICLE_BUS:
       cp_adas = can_parsers[Bus.adas]
 
@@ -30,6 +31,19 @@ class CarStateExt:
 
       ret.buttonEvents = [*create_button_events(self.infotainment_3_finger_press, prev_infotainment_3_finger_press,
                                                 {3: ButtonType.lkas})]
+
+    cp_party = can_parsers[Bus.party]
+    cp_ap_party = can_parsers[Bus.ap_party]
+
+    speed_units = self.can_define.dv["DI_state"]["DI_speedUnits"].get(int(cp_party.vl["DI_state"]["DI_speedUnits"]), None)
+    speed_limit = cp_ap_party.vl["DAS_status"]["DAS_fusedSpeedLimit"]
+    if self.can_define.dv["DAS_status"]["DAS_fusedSpeedLimit"].get(int(speed_limit), None) in ["NONE", "UNKNOWN_SNA"]:
+      ret_sp.speedLimit = 0
+    else:
+      if speed_units == "KPH":
+        ret_sp.speedLimit = speed_limit * CV.KPH_TO_MS
+      elif speed_units == "MPH":
+        ret_sp.speedLimit = speed_limit * CV.MPH_TO_MS
 
   @staticmethod
   def get_parser(CP: structs.CarParams, CP_SP: structs.CarParamsSP) -> dict[StrEnum, CANParser]:


### PR DESCRIPTION
This reads Tesla fused speed limit for use in Speed Limit Assist.


Tesla has following several speed limits on the CANbus:
```
DAS_visionOnlySpeedLimit (0-150 kph/mph)
DAS_fusedSpeedLimit (0-150 kph/mph)
```
`DAS_visionOnlySpeedLimit ` was fixed at `155` kph.
Only `DAS_fusedSpeedLimit`contained speed limit matching Tesla screen, and so it was used.

-----


<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
Validation
2a251bf8a265ff32/00000073--3ec0510d3b/4
(speed limit goes 50kph->40kph )

<img width="547" height="250" alt="image" src="https://github.com/user-attachments/assets/46870580-d7f0-41a5-a1d2-a550af565071" />

https://github.com/dzid26/sunnypilot/tree/speedlimit-tesla

------




## Summary by Sourcery

Read the Tesla fused speed limit from the CAN bus, convert it into m/s according to the vehicle’s speed units, default to zero if unavailable, and expose it on the CarStateSP interface.

New Features:
- Expose Tesla DAS_fusedSpeedLimit on the CarStateSP struct
- Convert the raw speed limit value to meters per second based on the vehicle’s configured speed units

Enhancements:
- Handle unknown or unavailable speed limits by setting speedLimit to zero
- Update CarStateExt.update signature to accept CarStateSP for speed limit propagation
- Update CarState update flow to pass CarStateSP into CarStateExt.update