### PR TITLE
Remove deprecated gas multipiler logic

### DIFF
--- a/opendbc/sunnypilot/car/honda/gas_interceptor.py
+++ b/opendbc/sunnypilot/car/honda/gas_interceptor.py
@@ -30,7 +30,7 @@ class GasInterceptorCarController:
       # Sending non-zero gas when OP is not enabled will cause the PCM not to respond to throttle as expected
       # when you do enable.
       if CC.longActive:
-        self.gas = float(np.clip(gas - brake + wind_brake * 3 / 4), 0., 1.)
+        self.gas = float(np.clip((gas - brake + wind_brake * 3 / 4), 0., 1.))
       else:
         self.gas = 0.0
       can_sends.append(create_gas_interceptor_command(packer, self.gas, frame // 2))


### PR DESCRIPTION
Gas multiplier logic was severely limiting acceleration with the newer longitudinal planner. The car is no longer aggressive at low speeds and gas_mult only severely hinders off the line acceleration

This may need verification on other Nidec Hondas due to possible differences in accelerator response. I can also recreate and retest due to the second commit where I fixed the typo if needed but this the same fork that the test route was on. 

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
Validation
* Dongle ID:  bec8599eef13a657
* Route: 0000000e--3de592cf07

## Summary by Sourcery

Remove deprecated gas multiplier logic from the Honda gas interceptor and apply raw gas values for a more responsive off-the-line acceleration

Enhancements:
- Eliminate gas_mult interpolation to simplify gas calculation
- Apply unclipped raw gas minus brake input to improve low-speed acceleration