### PR TITLE
interface: handle `None` parameters gracefully in interface initializations

### DIFF
--- a/opendbc/sunnypilot/car/interfaces.py
+++ b/opendbc/sunnypilot/car/interfaces.py
@@ -75,10 +75,11 @@ class NanoFFModel:
 
 
 def setup_interfaces(CI, CP: structs.CarParams, CP_SP: structs.CarParamsSP,
-                     params_list: list[dict[str, str]], can_recv: CanRecvCallable = None, can_send: CanSendCallable = None) -> None:
-  params_dict = {}
-  if params_list is not None:
-    params_dict = {k: v for param in params_list for k, v in param.items()}
+                     params_list: list[dict[str, str]] | None = None, can_recv: CanRecvCallable = None, can_send: CanSendCallable = None) -> None:
+  if params_list is None:
+    params_list = []
+
+  params_dict = {k: v for param in params_list for k, v in param.items()}
 
   _initialize_custom_longitudinal_tuning(CI, CP, CP_SP, params_dict)
   _initialize_coop_steering(CP, CP_SP, params_dict)
@@ -92,7 +93,7 @@ def _initialize_custom_longitudinal_tuning(CI, CP: structs.CarParams, CP_SP: str
 
   # Hyundai Custom Longitudinal Tuning
   if CP.brand == 'hyundai':
-    hyundai_longitudinal_tuning = int(params_dict["HyundaiLongitudinalTuning"])
+    hyundai_longitudinal_tuning = int(params_dict.get("HyundaiLongitudinalTuning", 0))
     if hyundai_longitudinal_tuning == LongitudinalTuningType.DYNAMIC:
       CP_SP.flags |= HyundaiFlagsSP.LONG_TUNING_DYNAMIC.value
     if hyundai_longitudinal_tuning == LongitudinalTuningType.PREDICTIVE:
@@ -118,8 +119,8 @@ def _initialize_radar_tracks(CP: structs.CarParams, CP_SP: structs.CarParamsSP, 
 
 def _initialize_stop_and_go(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params_dict: dict[str, str]) -> None:
   if CP.brand == 'subaru' and not CP.flags & (SubaruFlags.GLOBAL_GEN2 | SubaruFlags.HYBRID):
-    stop_and_go = int(params_dict["SubaruStopAndGo"]) == 1
-    stop_and_go_manual_parking_brake = int(params_dict["SubaruStopAndGoManualParkingBrake"]) == 1
+    stop_and_go = int(params_dict.get("SubaruStopAndGo", 0)) == 1
+    stop_and_go_manual_parking_brake = int(params_dict.get("SubaruStopAndGoManualParkingBrake", 0)) == 1
 
     if stop_and_go:
       CP_SP.flags |= SubaruFlagsSP.STOP_AND_GO.value
@@ -131,7 +132,7 @@ def _initialize_stop_and_go(CP: structs.CarParams, CP_SP: structs.CarParamsSP, p
 
 def _initialize_toyota(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params_dict: dict[str, str]) -> None:
   if CP.brand == 'toyota':
-    toyota_stock_long = int(params_dict["ToyotaEnforceStockLongitudinal"]) == 1
+    toyota_stock_long = int(params_dict.get("ToyotaEnforceStockLongitudinal", 0)) == 1
 
     if toyota_stock_long:
       CP_SP.flags |= ToyotaFlagsSP.STOCK_LONGITUDINAL.value


### PR DESCRIPTION
Check for None `Params_list` to fix the error:

```
/home/dzid_/sunnypilot/selfdrive/debug/run_process_on_route.py c8a98e58647765ad/00000138--6db3e6beb5/2 
Using cached CarParams
Using cached CarParams
VIN 00000000000000000
VIN 00000000000000000
{'event': 'fingerprinted', 'car_fingerprint': 'TESLA_MODEL_Y', 'source': 1, 'fuzzy': False, 'cached': True, 'fw_count': 1, 'ecu_responses': [], 'vin_rx_addr': -1, 'vin_rx_bus': -1, 'fingerprints': '{0: {258: 8, 725: 7, 49: 3, 880: 8, 909: 7, 50: 8, 257: 8, 273: 8, 264: 8, 280: 8, 259: 8, 310: 8, 485: 8, 322: 5, 576: 2, 394: 8, 598: 7, 1271: 6, 281: 8, 282: 8, 328: 8, 518: 8, 599: 8, 910: 6, 373: 8, 390: 8, 908: 4, 391: 8, 778: 8, 261: 8, 285: 8, 325: 8, 341: 8, 389: 8, 907: 4, 930: 8, 1009: 8, 1249: 4, 1265: 8, 794: 8, 911: 6, 925: 5, 546: 8, 611: 8, 545: 8, 785: 7, 646: 8, 294: 5, 1270: 7, 1861: 8, 421: 5, 744: 8, 993: 8, 680: 8, 949: 8, 260: 7, 567: 8, 901: 8, 817: 8, 914: 8, 977: 8, 628: 7, 690: 8, 1057: 8, 1365: 4, 615: 8, 822: 3, 823: 8, 1493: 3, 1869: 8, 924: 7, 1973: 3, 1974: 8, 1975: 1, 1976: 8}, 1: {1349: 8, 931: 8, 1930: 8, 313: 1, 737: 8, 642: 8, 297: 8, 1139: 8, 804: 8, 1523: 3, 947: 8, 536: 6, 1033: 1, 280: 8, 614: 8, 599: 8, 611: 8, 472: 8, 485: 8, 1666: 8, 469: 8, 915: 8, 1943: 4, 1885: 8, 609: 8, 798: 8, 306: 6, 504: 4, 541: 8, 882: 8, 605: 8, 890: 8, 962: 8, 741: 8, 1024: 7, 1025: 8, 1034: 8, 1053: 1, 1057: 7, 1089: 8, 930: 8, 1014: 8, 513: 8, 703: 7, 705: 8, 1091: 6, 524: 8, 897: 8, 1000: 8, 649: 8, 579: 8, 1114: 8, 554: 4, 857: 8, 1864: 5, 925: 5, 1251: 8, 670: 6, 727: 5, 1929: 4, 1960: 8, 673: 6, 1698: 5, 564: 8, 530: 8, 507: 8, 594: 8, 658: 6, 722: 8, 754: 2, 545: 8, 835: 8, 552: 8, 968: 8, 1250: 8, 1638: 4, 922: 8, 1370: 8, 1029: 8, 963: 8, 1655: 8, 610: 8, 585: 4, 555: 8, 1928: 8, 1976: 8, 1049: 1, 664: 3, 537: 7, 1363: 8, 1697: 5, 1962: 8, 842: 8, 1083: 8, 1362: 8, 1817: 8, 942: 8, 648: 8, 322: 8, 744: 8, 899: 8, 761: 8, 929: 8, 264: 8, 294: 5, 296: 4, 691: 8, 470: 8, 616: 5, 1058: 6, 633: 8, 694: 3, 917: 8, 919: 8, 1059: 7, 1096: 6, 1140: 5, 390: 8, 405: 8, 421: 5, 634: 8, 706: 8, 918: 8, 1017: 8, 1944: 8, 728: 2, 1056: 7, 79: 8, 956: 4, 819: 5, 820: 8, 1021: 8, 707: 8, 680: 8, 832: 8, 2005: 8, 825: 8, 2007: 8, 1879: 8, 738: 8, 770: 8, 1064: 6, 739: 7, 505: 8, 979: 3, 506: 3, 577: 7, 549: 4, 281: 3, 578: 3, 678: 8, 679: 8, 711: 8, 952: 8, 723: 8, 643: 6, 753: 8, 275: 3, 864: 8, 1081: 8, 2036: 1, 2047: 8, 792: 8, 1112: 7, 553: 3, 960: 8, 1359: 8, 603: 8, 258: 8, 1066: 8, 667: 4, 1013: 8, 259: 8, 290: 8, 529: 6, 889: 8, 291: 8, 626: 8, 708: 8, 516: 8, 612: 6, 548: 8, 692: 6, 721: 2, 938: 8, 1914: 8, 755: 8, 826: 8, 627: 8, 994: 7, 1828: 3, 1816: 7, 972: 8, 946: 8, 995: 4, 1001: 8, 776: 8, 921: 3, 660: 8, 936: 8, 2024: 8, 800: 8, 794: 8, 1565: 8, 568: 8, 810: 5, 914: 8, 1810: 8, 1009: 8, 562: 8, 1107: 4, 443: 1, 644: 8, 645: 8, 1830: 3, 771: 8, 1327: 8, 840: 8, 1320: 4, 1005: 1, 793: 8, 1801: 8, 2033: 7, 987: 8, 676: 8, 868: 4, 932: 8, 646: 5, 984: 4, 851: 8, 801: 8, 1768: 8, 787: 8, 991: 8, 1800: 5, 659: 8, 595: 8, 1267: 3, 531: 2, 1031: 7, 1850: 8, 850: 8, 969: 8, 1860: 1, 1831: 2, 1121: 8, 1992: 8, 886: 8, 982: 8, 1367: 5, 1622: 8, 854: 8, 855: 8, 858: 8, 859: 8, 1849: 5, 786: 8, 768: 8, 785: 2, 818: 6, 884: 8, 978: 8, 1010: 8, 1106: 3, 1138: 8, 1170: 7, 1834: 8, 1815: 7, 955: 2, 865: 5, 1316: 7, 790: 8, 772: 8, 777: 8, 789: 8, 941: 8, 950: 8, 898: 5, 981: 8, 1022: 8, 1495: 5, 821: 8, 935: 8, 949: 8, 965: 8, 997: 8, 871: 8, 872: 8, 875: 8, 878: 8, 1115: 2, 1859: 1, 2040: 8, 829: 8, 893: 8, 989: 8, 1736: 8, 1847: 7, 602: 6, 836: 8, 1364: 7, 1748: 8, 902: 8, 928: 8, 900: 8, 896: 8, 1973: 3, 870: 8, 586: 1, 883: 8, 522: 6, 853: 6, 1173: 6, 1082: 8, 866: 3, 803: 5, 907: 7, 909: 8, 1279: 4, 769: 8, 1874: 8, 816: 8, 1803: 8, 130: 8, 570: 8}, 2: {81: 3, 297: 8, 1160: 4, 1492: 8, 1509: 8, 665: 8, 521: 8, 524: 2, 697: 8, 847: 6, 637: 3, 283: 1, 522: 6, 2047: 8, 905: 8, 605: 6, 1488: 1, 923: 8, 811: 5, 659: 8}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}', 'fw_query_time': 0.0041030779993889155}
{'event': 'fingerprinted', 'car_fingerprint': 'TESLA_MODEL_Y', 'source': 1, 'fuzzy': False, 'cached': True, 'fw_count': 1, 'ecu_responses': [], 'vin_rx_addr': -1, 'vin_rx_bus': -1, 'fingerprints': '{0: {258: 8, 725: 7, 49: 3, 880: 8, 909: 7, 50: 8, 257: 8, 273: 8, 264: 8, 280: 8, 259: 8, 310: 8, 485: 8, 322: 5, 576: 2, 394: 8, 598: 7, 1271: 6, 281: 8, 282: 8, 328: 8, 518: 8, 599: 8, 910: 6, 373: 8, 390: 8, 908: 4, 391: 8, 778: 8, 261: 8, 285: 8, 325: 8, 341: 8, 389: 8, 907: 4, 930: 8, 1009: 8, 1249: 4, 1265: 8, 794: 8, 911: 6, 925: 5, 546: 8, 611: 8, 545: 8, 785: 7, 646: 8, 294: 5, 1270: 7, 1861: 8, 421: 5, 744: 8, 993: 8, 680: 8, 949: 8, 260: 7, 567: 8, 901: 8, 817: 8, 914: 8, 977: 8, 628: 7, 690: 8, 1057: 8, 1365: 4, 615: 8, 822: 3, 823: 8, 1493: 3, 1869: 8, 924: 7, 1973: 3, 1974: 8, 1975: 1, 1976: 8}, 1: {1349: 8, 931: 8, 1930: 8, 313: 1, 737: 8, 642: 8, 297: 8, 1139: 8, 804: 8, 1523: 3, 947: 8, 536: 6, 1033: 1, 280: 8, 614: 8, 599: 8, 611: 8, 472: 8, 485: 8, 1666: 8, 469: 8, 915: 8, 1943: 4, 1885: 8, 609: 8, 798: 8, 306: 6, 504: 4, 541: 8, 882: 8, 605: 8, 890: 8, 962: 8, 741: 8, 1024: 7, 1025: 8, 1034: 8, 1053: 1, 1057: 7, 1089: 8, 930: 8, 1014: 8, 513: 8, 703: 7, 705: 8, 1091: 6, 524: 8, 897: 8, 1000: 8, 649: 8, 579: 8, 1114: 8, 554: 4, 857: 8, 1864: 5, 925: 5, 1251: 8, 670: 6, 727: 5, 1929: 4, 1960: 8, 673: 6, 1698: 5, 564: 8, 530: 8, 507: 8, 594: 8, 658: 6, 722: 8, 754: 2, 545: 8, 835: 8, 552: 8, 968: 8, 1250: 8, 1638: 4, 922: 8, 1370: 8, 1029: 8, 963: 8, 1655: 8, 610: 8, 585: 4, 555: 8, 1928: 8, 1976: 8, 1049: 1, 664: 3, 537: 7, 1363: 8, 1697: 5, 1962: 8, 842: 8, 1083: 8, 1362: 8, 1817: 8, 942: 8, 648: 8, 322: 8, 744: 8, 899: 8, 761: 8, 929: 8, 264: 8, 294: 5, 296: 4, 691: 8, 470: 8, 616: 5, 1058: 6, 633: 8, 694: 3, 917: 8, 919: 8, 1059: 7, 1096: 6, 1140: 5, 390: 8, 405: 8, 421: 5, 634: 8, 706: 8, 918: 8, 1017: 8, 1944: 8, 728: 2, 1056: 7, 79: 8, 956: 4, 819: 5, 820: 8, 1021: 8, 707: 8, 680: 8, 832: 8, 2005: 8, 825: 8, 2007: 8, 1879: 8, 738: 8, 770: 8, 1064: 6, 739: 7, 505: 8, 979: 3, 506: 3, 577: 7, 549: 4, 281: 3, 578: 3, 678: 8, 679: 8, 711: 8, 952: 8, 723: 8, 643: 6, 753: 8, 275: 3, 864: 8, 1081: 8, 2036: 1, 2047: 8, 792: 8, 1112: 7, 553: 3, 960: 8, 1359: 8, 603: 8, 258: 8, 1066: 8, 667: 4, 1013: 8, 259: 8, 290: 8, 529: 6, 889: 8, 291: 8, 626: 8, 708: 8, 516: 8, 612: 6, 548: 8, 692: 6, 721: 2, 938: 8, 1914: 8, 755: 8, 826: 8, 627: 8, 994: 7, 1828: 3, 1816: 7, 972: 8, 946: 8, 995: 4, 1001: 8, 776: 8, 921: 3, 660: 8, 936: 8, 2024: 8, 800: 8, 794: 8, 1565: 8, 568: 8, 810: 5, 914: 8, 1810: 8, 1009: 8, 562: 8, 1107: 4, 443: 1, 644: 8, 645: 8, 1830: 3, 771: 8, 1327: 8, 840: 8, 1320: 4, 1005: 1, 793: 8, 1801: 8, 2033: 7, 987: 8, 676: 8, 868: 4, 932: 8, 646: 5, 984: 4, 851: 8, 801: 8, 1768: 8, 787: 8, 991: 8, 1800: 5, 659: 8, 595: 8, 1267: 3, 531: 2, 1031: 7, 1850: 8, 850: 8, 969: 8, 1860: 1, 1831: 2, 1121: 8, 1992: 8, 886: 8, 982: 8, 1367: 5, 1622: 8, 854: 8, 855: 8, 858: 8, 859: 8, 1849: 5, 786: 8, 768: 8, 785: 2, 818: 6, 884: 8, 978: 8, 1010: 8, 1106: 3, 1138: 8, 1170: 7, 1834: 8, 1815: 7, 955: 2, 865: 5, 1316: 7, 790: 8, 772: 8, 777: 8, 789: 8, 941: 8, 950: 8, 898: 5, 981: 8, 1022: 8, 1495: 5, 821: 8, 935: 8, 949: 8, 965: 8, 997: 8, 871: 8, 872: 8, 875: 8, 878: 8, 1115: 2, 1859: 1, 2040: 8, 829: 8, 893: 8, 989: 8, 1736: 8, 1847: 7, 602: 6, 836: 8, 1364: 7, 1748: 8, 902: 8, 928: 8, 900: 8, 896: 8, 1973: 3, 870: 8, 586: 1, 883: 8, 522: 6, 853: 6, 1173: 6, 1082: 8, 866: 3, 803: 5, 907: 7, 909: 8, 1279: 4, 769: 8, 1874: 8, 816: 8, 1803: 8, 130: 8, 570: 8}, 2: {81: 3, 297: 8, 1160: 4, 1492: 8, 1509: 8, 665: 8, 521: 8, 524: 2, 697: 8, 847: 6, 637: 3, 283: 1, 522: 6, 2047: 8, 905: 8, 605: 6, 1488: 1, 923: 8, 811: 5, 659: 8}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}}', 'fw_query_time': 0.0041030779993889155}
Traceback (most recent call last):
  File "/usr/lib/python3.12/runpy.py", line 198, in _run_module_as_main
    return _run_code(code, main_globals, None,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/runpy.py", line 88, in _run_code
    exec(code, run_globals)
  File "/home/dzid_/.windsurf-server/extensions/ms-python.debugpy-2025.14.1-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 71, in <module>
    cli.main()
  File "/home/dzid_/.windsurf-server/extensions/ms-python.debugpy-2025.14.1-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 508, in main
    run()
  File "/home/dzid_/.windsurf-server/extensions/ms-python.debugpy-2025.14.1-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 358, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/home/dzid_/.windsurf-server/extensions/ms-python.debugpy-2025.14.1-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 310, in run_path
    return _run_module_code(code, init_globals, run_name, pkg_name=pkg_name, script_name=fname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dzid_/.windsurf-server/extensions/ms-python.debugpy-2025.14.1-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 127, in _run_module_code
    _run_code(code, mod_globals, init_globals, mod_name, mod_spec, pkg_name, script_name)
  File "/home/dzid_/.windsurf-server/extensions/ms-python.debugpy-2025.14.1-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 118, in _run_code
    exec(code, run_globals)
  File "/home/dzid_/sunnypilot/selfdrive/debug/run_process_on_route.py", line 23, in <module>
    outputs = replay_process(cfgs, inputs, fingerprint=args.fingerprint)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dzid_/sunnypilot/openpilot/selfdrive/test/process_replay/process_replay.py", line 630, in replay_process
    process_logs = _replay_multi_process(cfgs, all_msgs, frs, fingerprint, custom_params, captured_output_store, disable_progress)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dzid_/sunnypilot/openpilot/selfdrive/test/process_replay/process_replay.py", line 672, in _replay_multi_process
    container.start(params_config, env_config, all_msgs, frs, fingerprint, captured_output_store is not None)
  File "/home/dzid_/sunnypilot/openpilot/selfdrive/test/process_replay/process_replay.py", line 249, in start
    self.cfg.init_callback(self.rc, self.pm, all_msgs, fingerprint)
  File "/home/dzid_/sunnypilot/openpilot/selfdrive/test/process_replay/process_replay.py", line 359, in get_car_params_callback
    _CI = get_car(can_recv, lambda _msgs: None, lambda obd: None, params.get_bool("AlphaLongitudinalEnabled"), False, cached_params=cached_params)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dzid_/sunnypilot/opendbc/car/car_helpers.py", line 172, in get_car
    sunnypilot_interfaces(CarInterface, CP, CP_SP, init_params_list_sp, can_recv, can_send)
  File "/home/dzid_/sunnypilot/opendbc/sunnypilot/car/interfaces.py", line 75, in setup_interfaces
    params_dict = {k: v for param in params_list for k, v in param.items()}
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

## Summary by Sourcery

Bug Fixes:
- Add a None check for params_list before building params_dict in setup_interfaces