### PR TITLE
Nissan: enable acc button sending in safety & fix Leaf cancel button

### DIFF
--- a/opendbc/safety/tests/test_nissan.py
+++ b/opendbc/safety/tests/test_nissan.py
@@ -11,10 +11,10 @@ from opendbc.safety.tests.common import CANPackerPanda
 
 class TestNissanSafety(common.PandaCarSafetyTest, common.AngleSteeringSafetyTest):
 
-  TX_MSGS = [[0x169, 0], [0x2b1, 0], [0x4cc, 0], [0x20b, 2], [0x280, 2]]
+  TX_MSGS = [[0x169, 0], [0x2b1, 0], [0x4cc, 0], [0x20b, 2]]
   GAS_PRESSED_THRESHOLD = 3
-  RELAY_MALFUNCTION_ADDRS = {0: (0x169, 0x2b1, 0x4cc), 2: (0x280,)}
-  FWD_BLACKLISTED_ADDRS = {0: [0x280], 2: [0x169, 0x2b1, 0x4cc]}
+  RELAY_MALFUNCTION_ADDRS = {0: (0x169, 0x2b1, 0x4cc), 2: (0x20b,)}
+  FWD_BLACKLISTED_ADDRS = {0: [0x20b], 2: [0x169, 0x2b1, 0x4cc]}
 
   EPS_BUS = 0
   CRUISE_BUS = 2
@@ -67,16 +67,16 @@ class TestNissanSafety(common.PandaCarSafetyTest, common.AngleSteeringSafetyTest
     values = {"CANCEL_BUTTON": cancel, "PROPILOT_BUTTON": propilot,
               "FOLLOW_DISTANCE_BUTTON": flw_dist, "SET_BUTTON": _set,
               "RES_BUTTON": res, "NO_BUTTON_PRESSED": no_button}
-    return self.packer.make_can_msg_panda("CRUISE_THROTTLE", 2, values)
+    return self.packer.make_can_msg_panda("CRUISE_THROTTLE", self.CRUISE_BUS, values)
 
   def test_acc_buttons(self):
     btns = [
       ("cancel", True),
-      ("propilot", False),
-      ("flw_dist", False),
-      ("_set", False),
-      ("res", False),
-      (None, False),
+      ("propilot", True),
+      ("flw_dist", True),
+      ("_set", True),
+      ("res", True),
+      (None, True),
     ]
     for controls_allowed in (True, False):
       for btn, should_tx in btns:
@@ -93,6 +93,10 @@ class TestNissanSafetyAltEpsBus(TestNissanSafety):
   CRUISE_BUS = 1
   ACC_MAIN_BUS = 2
 
+  TX_MSGS = [[0x169, 0], [0x2b1, 0], [0x4cc, 0], [0x20b, 2]]
+  RELAY_MALFUNCTION_ADDRS = {0: (0x169, 0x2b1, 0x4cc)}
+  FWD_BLACKLISTED_ADDRS = {2: [0x169, 0x2b1, 0x4cc]}
+
   def setUp(self):
     self.packer = CANPackerPanda("nissan_x_trail_2017_generated")
     self.safety = libsafety_py.libsafety
@@ -101,6 +105,10 @@ class TestNissanSafetyAltEpsBus(TestNissanSafety):
 
 
 class TestNissanLeafSafety(TestNissanSafety):
+
+  TX_MSGS = [[0x169, 0], [0x2b1, 0], [0x4cc, 0], [0x239, 2]]
+  RELAY_MALFUNCTION_ADDRS = {0: (0x169, 0x2b1, 0x4cc), 2: (0x239,)}
+  FWD_BLACKLISTED_ADDRS = {0: [0x239], 2: [0x169, 0x2b1, 0x4cc]}
 
   def setUp(self):
     self.packer = CANPackerPanda("nissan_leaf_2018_generated")
@@ -120,10 +128,6 @@ class TestNissanLeafSafety(TestNissanSafety):
   def _acc_state_msg(self, main_on):
     values = {"CRUISE_AVAILABLE": main_on}
     return self.packer.make_can_msg_panda("CRUISE_THROTTLE", 0, values)
-
-  # TODO: leaf should use its own safety param
-  def test_acc_buttons(self):
-    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
Validation
* Dongle ID: 
* Route:

## Summary by Sourcery

Enable forwarding of ACC control buttons and fix cancel implementation for Nissan vehicles by unifying cruise throttle message generation, updating safety hooks, and consolidating model-specific CAN TX configurations.

New Features:
- Support forwarding of all ACC control buttons (cancel, propilot, follow distance, set, resume) in safety on Nissan vehicles.
- Unify cruise throttle message creation with a frame-based counter and button signaling for cancel and other commands.

Bug Fixes:
- Fix Leaf cancel button by replacing the seatbelt relay hack with a proper cancel button signal in the throttle message.

Enhancements:
- Refactor safety configuration to use separate TX message sets for Nissan Leaf, X-Trail, and Altima with correct relay settings.
- Simplify carcontroller logic by consolidating ACC cancel and throttle message creation into a single function.

Tests:
- Update Nissan safety tests to match new TX message tables and verify ACC button sending for all button types.