### PR TITLE
ICBM: Hyundai CAN FD: button counter does not count to the max

### DIFF
--- a/opendbc/sunnypilot/car/hyundai/icbm.py
+++ b/opendbc/sunnypilot/car/hyundai/icbm.py
@@ -55,7 +55,7 @@ class IntelligentCruiseButtonManagementInterface(IntelligentCruiseButtonManageme
         button_counter_offset = [1, 1, 0, None][self.button_frame % 4]
         if button_counter_offset is not None:
           for _ in range(20):
-            can_sends.append(hyundaicanfd.create_buttons(packer, self.CP, CAN, (CS.buttons_counter + button_counter_offset) % 0x10, send_button))
+            can_sends.append(hyundaicanfd.create_buttons(packer, self.CP, CAN, (CS.buttons_counter + button_counter_offset) % 0xF, send_button))
           self.last_button_frame = self.frame
 
     return can_sends


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Change the button counter modulo from 0x10 to 0xF to ensure the counter counts up to its intended max.