### PR TITLE
Toyota: Automatically Lock and Unlock 

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -16,6 +16,7 @@ from opendbc.can import CANPacker
 
 from opendbc.sunnypilot.car.toyota.gas_interceptor import GasInterceptorCarController
 from opendbc.sunnypilot.car.toyota.secoc_long import SecOCLongCarController
+from opendbc.sunnypilot.car.toyota.auto_lock_unlock import AutoLockController
 
 Ecu = structs.CarParams.Ecu
 LongCtrlState = structs.CarControl.Actuators.LongControlState
@@ -83,6 +84,8 @@ class CarController(CarControllerBase, SecOCLongCarController, GasInterceptorCar
     self.secoc_lta_message_counter = 0
     self.secoc_prev_reset_counter = 0
 
+    self.auto_lock_controller = AutoLockController(self.CP_SP)
+
   def update(self, CC, CC_SP, CS, now_nanos):
     actuators = CC.actuators
     stopping = actuators.longControlState == LongCtrlState.stopping
@@ -96,6 +99,8 @@ class CarController(CarControllerBase, SecOCLongCarController, GasInterceptorCar
 
     # *** control msgs ***
     can_sends = []
+
+    can_sends.extend(self.auto_lock_controller.update(CS))
 
     SecOCLongCarController.update(self, CS, can_sends, self.secoc_prev_reset_counter)
 

--- a/opendbc/safety/modes/toyota.h
+++ b/opendbc/safety/modes/toyota.h
@@ -395,12 +395,12 @@ static bool toyota_tx_hook(const CANPacket_t *msg) {
     // this address is sub-addressed. only allow tester present to radar (0xF)
     bool invalid_uds_msg = (GET_BYTES(msg, 0, 4) == 0x003E020FU) && (GET_BYTES(msg, 4, 4) == 0x0U);
 
-    bool sp_valid_uds_msgs = (GET_BYTES(msg, 0, 4) == 0x11300540U) &&  // automatic door locking and unlocking
-                             ((GET_BYTES(msg, 4, 4) == 0x00004000U)  // unlock
-                             || (GET_BYTES(msg, 4, 4) == 0x00008000U));   // lock
+    bool is_auto_lock_unlock = (GET_BYTES(msg, 0, 4) == 0x11300540U) &&  // door lock/unlock command
+                               ((GET_BYTES(msg, 4, 4) == 0x00004000U) ||  // unlock
+                                (GET_BYTES(msg, 4, 4) == 0x00008000U));   // lock
 
-    // Allow if: (tester present OR auto lock/unlock) AND not stock long AND not SecOC
-    bool should_allow = (invalid_uds_msg || sp_valid_uds_msgs) && !toyota_stock_longitudinal && !toyota_secoc;
+    // Block if not allowed: must be (tester present OR auto lock/unlock) AND not stock long AND not SecOC
+    bool should_allow = (invalid_uds_msg || is_auto_lock_unlock) && !toyota_stock_longitudinal && !toyota_secoc;
 
     if (!should_allow) {
       tx = false;

--- a/opendbc/safety/modes/toyota.h
+++ b/opendbc/safety/modes/toyota.h
@@ -396,8 +396,8 @@ static bool toyota_tx_hook(const CANPacket_t *msg) {
     bool invalid_uds_msg = (GET_BYTES(msg, 0, 4) == 0x003E020FU) && (GET_BYTES(msg, 4, 4) == 0x0U);
 
     bool sp_valid_uds_msgs = (GET_BYTES(msg, 0, 4) == 0x11300540U) &&  // automatic door locking and unlocking
-                             ((GET_BYTES(msg, 4, 4) == 0x00004000U) ||  // unlock
-                              (GET_BYTES(msg, 4, 4) == 0x00008000U));   // lock
+                             ((GET_BYTES(msg, 4, 4) == 0x00004000U)  // unlock
+                             || (GET_BYTES(msg, 4, 4) == 0x00008000U));   // lock
 
     // Allow if: (tester present OR auto lock/unlock) AND not stock long AND not SecOC
     bool should_allow = (invalid_uds_msg || sp_valid_uds_msgs) && !toyota_stock_longitudinal && !toyota_secoc;

--- a/opendbc/safety/modes/toyota.h
+++ b/opendbc/safety/modes/toyota.h
@@ -396,8 +396,7 @@ static bool toyota_tx_hook(const CANPacket_t *msg) {
     bool invalid_uds_msg = (GET_BYTES(msg, 0, 4) == 0x003E020FU) && (GET_BYTES(msg, 4, 4) == 0x0U);
 
     bool is_auto_lock_unlock = (GET_BYTES(msg, 0, 4) == 0x11300540U) &&  // door lock/unlock command
-                               ((GET_BYTES(msg, 4, 4) == 0x00004000U) ||  // unlock
-                                (GET_BYTES(msg, 4, 4) == 0x00008000U));   // lock
+                               ((GET_BYTES(msg, 4, 4) == 0x00004000U) || (GET_BYTES(msg, 4, 4) == 0x00008000U));
 
     // Block if not allowed: must be (tester present OR auto lock/unlock) AND not stock long AND not SecOC
     bool should_allow = (invalid_uds_msg || is_auto_lock_unlock) && !toyota_stock_longitudinal && !toyota_secoc;

--- a/opendbc/sunnypilot/car/interfaces.py
+++ b/opendbc/sunnypilot/car/interfaces.py
@@ -17,6 +17,7 @@ from opendbc.sunnypilot.car.hyundai.enable_radar_tracks import enable_radar_trac
 from opendbc.sunnypilot.car.hyundai.longitudinal.helpers import LongitudinalTuningType
 from opendbc.sunnypilot.car.hyundai.values import HyundaiFlagsSP
 from opendbc.sunnypilot.car.subaru.values_ext import SubaruFlagsSP, SubaruSafetyFlagsSP
+from opendbc.sunnypilot.car.toyota.values import ToyotaFlagsSP
 
 
 class LatControlInputs(NamedTuple):
@@ -79,6 +80,7 @@ def setup_interfaces(CI, CP: structs.CarParams, CP_SP: structs.CarParamsSP,
   _initialize_custom_longitudinal_tuning(CI, CP, CP_SP, params_dict)
   _initialize_radar_tracks(CP, CP_SP, can_recv, can_send)
   _initialize_stop_and_go(CP, CP_SP, params_dict)
+  _initialize_toyota(CP, CP_SP, params_dict)
 
 
 def _initialize_custom_longitudinal_tuning(CI, CP: structs.CarParams, CP_SP: structs.CarParamsSP,
@@ -113,3 +115,14 @@ def _initialize_stop_and_go(CP: structs.CarParams, CP_SP: structs.CarParamsSP, p
       CP_SP.flags |= SubaruFlagsSP.STOP_AND_GO_MANUAL_PARKING_BRAKE.value
     if stop_and_go or stop_and_go_manual_parking_brake:
       CP_SP.safetyParam |= SubaruSafetyFlagsSP.STOP_AND_GO
+
+
+def _initialize_toyota(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params_dict: dict[str, str]) -> None:
+  if CP.brand == 'toyota':
+    toyota_auto_lock = int(params_dict["ToyotaAutoLock"])
+    toyota_auto_unlock = int(params_dict["ToyotaAutoUnlock"])
+
+    if toyota_auto_lock:
+      CP_SP.flags |= ToyotaFlagsSP.AUTO_LOCK
+    if toyota_auto_unlock:
+      CP_SP.flags |= ToyotaFlagsSP.AUTO_UNLOCK

--- a/opendbc/sunnypilot/car/toyota/auto_lock_unlock.py
+++ b/opendbc/sunnypilot/car/toyota/auto_lock_unlock.py
@@ -1,0 +1,61 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+automatic door locking and unlocking logic (@dragonpilot-community)
+thanks to AlexandreSato & cydia2020
+https://github.com/AlexandreSato/animalpilot/blob/personal/doors.py
+"""
+
+from opendbc.car import structs
+from opendbc.car.common.conversions import Conversions as CV
+from opendbc.car.can_definitions import CanData
+from opendbc.sunnypilot.car.toyota.values import ToyotaFlagsSP
+
+GearShifter = structs.CarState.GearShifter
+
+UNLOCK_CMD = b'\x40\x05\x30\x11\x00\x40\x00\x00'
+LOCK_CMD = b'\x40\x05\x30\x11\x00\x80\x00\x00'
+LOCK_AT_SPEED = 10 * CV.KPH_TO_MS
+
+
+class AutoLockController:
+  def __init__(self, CP_SP):
+    self.auto_lock_enabled = CP_SP.flags & ToyotaFlagsSP.AUTO_LOCK.value
+    self.auto_unlock_enabled = CP_SP.flags & ToyotaFlagsSP.AUTO_UNLOCK.value
+    self.last_gear = GearShifter.park
+    self.lock_once = False
+
+  def update(self, CS) -> list[CanData]:
+    can_sends = []
+
+    if not self.auto_lock_enabled and not self.auto_unlock_enabled:
+      return can_sends
+
+    current_gear = CS.out.gearShifter
+    if self.last_gear != current_gear and current_gear == GearShifter.park:
+      # Auto unlock when shifting to Park
+      if self.auto_unlock_enabled:
+        can_sends.append(CanData(0x750, UNLOCK_CMD, 0))
+
+      if self.auto_lock_enabled:
+        self.lock_once = False
+
+    elif self.auto_lock_enabled:
+      # Conditions for auto lock:
+      # - In Drive gear
+      # - Doors are closed
+      # - Haven't locked yet this drive cycle
+      # - Speed is above threshold
+      if (current_gear == GearShifter.drive and not CS.out.doorOpen and not self.lock_once and CS.out.vEgo >= LOCK_AT_SPEED):
+        can_sends.append(CanData(0x750, LOCK_CMD, 0))
+        self.lock_once = True
+
+    self.last_gear = current_gear
+    return can_sends
+
+  def reset(self):
+    self.last_gear = GearShifter.park
+    self.lock_once = False

--- a/opendbc/sunnypilot/car/toyota/values.py
+++ b/opendbc/sunnypilot/car/toyota/values.py
@@ -12,6 +12,8 @@ class ToyotaFlagsSP(IntFlag):
   SMART_DSU = 1
   RADAR_CAN_FILTER = 2
   ZSS = 4
+  AUTO_LOCK = 8
+  AUTO_UNLOCK = 16
 
 
 class ToyotaSafetyFlagsSP:


### PR DESCRIPTION
## Summary by Sourcery

Enable automatic door locking and unlocking on Toyota vehicles by introducing a new AutoLockController, adding safety flags, and extending the safety transmit hook to allow the required UDS messages.

New Features:
- Add AutoLockController to automatically send lock/unlock commands based on gear shifts, door state, and vehicle speed
- Introduce AUTO_LOCK and AUTO_UNLOCK safety flags for Toyota to enable the feature per user configuration

Enhancements:
- Permit UDS lock/unlock messages on CAN address 0x750 in Toyota safety hook when automatic lock/unlock is enabled and safety conditions are met