### PR TITLE
Allowing `to_dict` on `CP_SP` like `CP`

### DIFF
--- a/opendbc/car/structs.py
+++ b/opendbc/car/structs.py
@@ -82,6 +82,7 @@ class CarParamsSP:
   def to_dict(self):
     return {k: str(v) for k, v in asdict(self).items()}
 
+
 @auto_dataclass
 class ModularAssistiveDrivingSystem:
   state: 'ModularAssistiveDrivingSystem.ModularAssistiveDrivingSystemState' = field(


### PR DESCRIPTION
This allows us to use the method `to_dict()` like it is available for `CP` . This happens because `CP` is `_DynamicStructBuilder` while `CP_SP` is an actual dataclass in `structs`. 

<img width="767" height="54" alt="image" src="https://github.com/user-attachments/assets/a10fbc2a-ab13-4bc1-839c-e4e9ba500be6" />

This should make it easier to work with either, otherwise you'll go down the same rabbithole I did

## Summary by Sourcery

New Features:
- Add to_dict method to Model dataclass to convert instance fields to string-valued dictionary