### PR TITLE
Subaru: Port tizi Stop and Go support (beta)

### DIFF
--- a/opendbc/car/subaru/carstate.py
+++ b/opendbc/car/subaru/carstate.py
@@ -7,12 +7,14 @@ from opendbc.car.subaru.values import DBC, CanBus, SubaruFlags
 from opendbc.car import CanSignalRateCalculator
 
 from opendbc.sunnypilot.car.subaru.mads import MadsCarState
+from opendbc.sunnypilot.car.subaru.stop_and_go import SnGCarState
 
 
-class CarState(CarStateBase, MadsCarState):
+class CarState(CarStateBase, MadsCarState, SnGCarState):
   def __init__(self, CP, CP_SP):
     CarStateBase.__init__(self, CP, CP_SP)
     MadsCarState.__init__(self, CP, CP_SP)
+    SnGCarState.__init__(self, CP, CP_SP)
     can_define = CANDefine(DBC[CP.carFingerprint][Bus.pt])
     self.shifter_values = can_define.dv["Transmission"]["Gear"]
 
@@ -128,6 +130,7 @@ class CarState(CarStateBase, MadsCarState):
       self.es_infotainment_msg = copy.copy(cp_cam.vl["ES_Infotainment"])
 
     MadsCarState.update_mads(self, ret, can_parsers)
+    SnGCarState.update(self, ret, can_parsers)
 
     return ret, ret_sp
 

--- a/opendbc/car/subaru/interface.py
+++ b/opendbc/car/subaru/interface.py
@@ -103,6 +103,9 @@ class CarInterface(CarInterfaceBase):
                      car_fw: list[structs.CarParams.CarFw], alpha_long: bool, docs: bool) -> structs.CarParamsSP:
     stock_cp.dashcamOnly = bool(stock_cp.flags & (SubaruFlags.LKAS_ANGLE | SubaruFlags.HYBRID))
 
+    if not stock_cp.flags & (SubaruFlags.GLOBAL_GEN2 | SubaruFlags.HYBRID):
+      stock_cp.autoResumeSng = True
+
     return ret
 
   @staticmethod

--- a/opendbc/dbc/generator/subaru/_subaru_preglobal_2015.dbc
+++ b/opendbc/dbc/generator/subaru/_subaru_preglobal_2015.dbc
@@ -49,6 +49,7 @@ BO_ 208 G_Sensor: 8 XXX
 BO_ 209 Brake_Pedal: 4 XXX
  SG_ Speed : 0|16@1+ (0.05625,0) [0|255] "KPH" XXX
  SG_ Brake_Pedal : 16|8@1+ (1,0) [0|255] "" XXX
+ SG_ Signal1 : 24|8@1+ (1,0) [0|255] "" XXX
 
 BO_ 210 Brake_2: 8 XXX
  SG_ Brake_Light : 35|1@1+ (1,0) [0|1] "" XXX

--- a/opendbc/safety/modes/subaru_common.h
+++ b/opendbc/safety/modes/subaru_common.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+extern bool subaru_stop_and_go;
+bool subaru_stop_and_go = false;
+
+void subaru_common_init(void) {
+  const int SUBARU_PARAM_SP_STOP_AND_GO = 1;
+
+  subaru_stop_and_go = GET_FLAG(current_safety_param_sp, SUBARU_PARAM_SP_STOP_AND_GO);
+}
+
+/*
+bool subaru_common_stop_and_go_throttle_check(const int throttle_pedal) {
+  bool violation = throttle_pedal != 5U || !controls_allowed || vehicle_moving;
+  return violation;
+}
+
+bool subaru_common_stop_and_go_brake_pedal_check(const int speed, const bool is_preglobal) {
+  int val = is_preglobal ? 1U : 3U;
+  bool violation = speed != val || !controls_allowed || vehicle_moving;
+  return violation;
+}
+*/

--- a/opendbc/sunnypilot/car/subaru/stop_and_go.py
+++ b/opendbc/sunnypilot/car/subaru/stop_and_go.py
@@ -1,0 +1,124 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+
+import copy
+from enum import StrEnum
+
+from opendbc.car import Bus, structs, DT_CTRL
+from opendbc.car.can_definitions import CanData
+from opendbc.car.interfaces import CarStateBase
+from opendbc.car.subaru.values import SubaruFlags
+
+from opendbc.sunnypilot.car.subaru import subarucan_ext
+from opendbc.sunnypilot.car.subaru.values_ext import SubaruFlagsSP
+from opendbc.can.parser import CANParser
+
+_SNG_ACC_MIN_DIST = 3
+_SNG_ACC_MAX_DIST = 4.5
+
+
+class SnGCarController:
+  def __init__(self, CP: structs.CarParams, CP_SP: structs.CarParamsSP):
+    self.CP = CP
+    self.CP_SP = CP_SP
+    self.enabled = CP_SP.flags & (SubaruFlagsSP.STOP_AND_GO | SubaruFlagsSP.STOP_AND_GO_MANUAL_PARKING_BRAKE)
+    self.manual_parking_brake = CP_SP.flags & SubaruFlagsSP.STOP_AND_GO_MANUAL_PARKING_BRAKE
+
+    self.last_standstill_frame = 0
+    self.epb_resume_frames_remaining = -1
+    self.prev_close_distance = 0.0
+
+  def update_epb_resume_sequence(self, should_resume: bool) -> bool:
+    if self.manual_parking_brake:
+      return False
+
+    if should_resume:
+      self.epb_resume_frames_remaining = 15
+
+    send_resume = self.epb_resume_frames_remaining > 0
+    if self.epb_resume_frames_remaining > 0:
+      self.epb_resume_frames_remaining -= 1
+
+    return send_resume
+
+  def update_stop_and_go(self, CC: structs.CarControl, CS: CarStateBase, frame: int) -> bool:
+    """
+    Manages stop-and-go functionality for adaptive cruise control (ACC).
+
+    Args:
+        CC: Car control data
+        CS: Car state data
+        frame: Current frame number
+
+    Returns:
+        bool: True if resume command should be sent, False otherwise
+    """
+
+    if not CC.enabled or not CC.hudControl.leadVisible:
+      return False
+
+    close_distance = CS.es_distance_msg["Close_Distance"]
+    in_standstill = CS.out.standstill
+
+    if not in_standstill:
+      self.last_standstill_frame = frame
+
+    # Check if we've been in standstill long enough
+    mpb_standstill_timers = (0.75, 0.8) if self.CP.flags & SubaruFlags.PREGLOBAL else (0.5, 0.55)
+    standstill_duration = (frame - self.last_standstill_frame) * DT_CTRL
+    in_standstill_hold = standstill_duration > mpb_standstill_timers[0]
+    if (frame - self.last_standstill_frame) * DT_CTRL >= mpb_standstill_timers[1]:
+      self.last_standstill_frame = frame
+
+    # Car state distance-based conditions (EPB only)
+    in_resume_distance = _SNG_ACC_MIN_DIST < close_distance < _SNG_ACC_MAX_DIST
+    distance_increasing = close_distance > self.prev_close_distance
+    distance_resume_allowed = in_resume_distance and distance_increasing
+
+    if self.manual_parking_brake:
+      # Manual parking brake: Direct resume when the standstill hold threshold is reached to prevent ACC fault
+      send_resume = in_standstill_hold
+    else:
+      # EPB: Resume sequence with trigger on distance with lead car increasing
+      should_resume = CS.out.standstill and distance_resume_allowed
+      send_resume = self.update_epb_resume_sequence(should_resume)
+
+    self.prev_close_distance = close_distance
+
+    return send_resume
+
+  def create_stop_and_go(self, packer, CC: structs.CarControl, CS: CarStateBase, frame: int) -> list[CanData]:
+    can_sends = []
+
+    if not self.enabled:
+      return can_sends
+
+    send_resume = self.update_stop_and_go(CC, CS, frame)
+
+    can_sends.append(subarucan_ext.create_throttle(packer, self.CP, CS.throttle_msg, send_resume and not self.manual_parking_brake))
+
+    if frame % 2 == 0:
+      can_sends.append(subarucan_ext.create_brake_pedal(packer, self.CP, CS.brake_pedal_msg, send_resume and self.manual_parking_brake))
+
+    return can_sends
+
+
+class SnGCarState:
+  def __init__(self, CP: structs.CarParams, CP_SP: structs.CarParamsSP):
+    self.CP = CP
+    self.CP_SP = CP_SP
+
+    self.brake_pedal_msg: dict[str, float] = {}
+    self.throttle_msg: dict[str, float] = {}
+
+  def update(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser]) -> None:
+    cp = can_parsers[Bus.pt]
+
+    self.brake_pedal_msg = copy.copy(cp.vl["Brake_Pedal"])
+
+    if not self.CP.flags & SubaruFlags.HYBRID:
+      self.throttle_msg = copy.copy(cp.vl["Throttle"])

--- a/opendbc/sunnypilot/car/subaru/subarucan_ext.py
+++ b/opendbc/sunnypilot/car/subaru/subarucan_ext.py
@@ -1,0 +1,68 @@
+from opendbc.car.subaru.values import CanBus, SubaruFlags
+
+
+def create_counter(msg):
+  return (msg["COUNTER"] + 1) % 0x10
+
+
+def create_throttle(packer, CP, throttle_msg, send_resume):
+  if CP.flags & SubaruFlags.PREGLOBAL:
+    values = {s: throttle_msg[s] for s in [
+      "Throttle_Pedal",
+      "Signal1",
+      "Not_Full_Throttle",
+      "Signal2",
+      "Engine_RPM",
+      "Off_Throttle",
+      "Signal3",
+      "Throttle_Cruise",
+      "Throttle_Combo",
+      "Throttle_Body",
+      "Off_Throttle_2",
+      "Signal4",
+    ]}
+  else:
+    values = {s: throttle_msg[s] for s in [
+      "CHECKSUM",
+      "Signal1",
+      "Engine_RPM",
+      "Signal2",
+      "Throttle_Pedal",
+      "Throttle_Cruise",
+      "Throttle_Combo",
+      "Signal3",
+      "Off_Accel",
+    ]}
+
+  values["COUNTER"] = create_counter(throttle_msg)
+
+  if send_resume:
+    values["Throttle_Pedal"] = 5
+
+  return packer.make_can_msg("Throttle", CanBus.camera, values)
+
+
+def create_brake_pedal(packer, CP, brake_pedal_msg, send_resume):
+  if CP.flags & SubaruFlags.PREGLOBAL:
+    values = {s: brake_pedal_msg[s] for s in [
+      "Speed",
+      "Brake_Pedal",
+      "Signal1",
+    ]}
+  else:
+    values = {s: brake_pedal_msg[s] for s in [
+      "CHECKSUM",
+      "Signal1",
+      "Speed",
+      "Signal2",
+      "Brake_Lights",
+      "Signal3",
+      "Brake_Pedal",
+      "Signal4",
+    ]}
+    values["COUNTER"] = create_counter(brake_pedal_msg)
+
+  if send_resume:
+    values["Speed"] = 1 if CP.flags & SubaruFlags.PREGLOBAL else 3
+
+  return packer.make_can_msg("Brake_Pedal", CanBus.camera, values)

--- a/opendbc/sunnypilot/car/subaru/values_ext.py
+++ b/opendbc/sunnypilot/car/subaru/values_ext.py
@@ -1,0 +1,17 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+
+from enum import IntFlag
+
+
+class SubaruSafetyFlagsSP:
+  STOP_AND_GO = 1
+
+
+class SubaruFlagsSP(IntFlag):
+  STOP_AND_GO = 1
+  STOP_AND_GO_MANUAL_PARKING_BRAKE = 2


### PR DESCRIPTION
I have no idea if it's as simple as cherry-picking the squashed commit from the original PR into master, but I figured I'd PR it to find out.

Edit: I didn't realize checks wouldn't run without approval, but in retrospect that makes perfect sense. When I have a chance, I'll give running tests locally a shot.

* Subaru: Stop and Go auto-resume support

* remove stock acc distance checks

* less!

* fix

* no longer needed

* both have the standstill signal

* fix init

* not needed

* wat

* make them all to use wheel speed

* safety init

* no counter for pre global

* set them properly

* fix it

* only send at 10

* 5 is fine

* no need for pre global

* Revert "no need for pre global"

This reverts commit cfd4e71feb8a0694db613865de5b5095bced44ed.

* bring back pcm distance check

* forget about planner resume, it sucks

* try to send off_accel

* still need it

* send this for pre global

* always send

* disable safety checks for now

* same

* more

* all the time for both

* don't need i guess

* unused

* be explicit

* fix init

* always -1

* try 15 frames per try

* all should have it

* try 3 for all

* use throttle for all preglobal?

* Revert "use throttle for all preglobal?"

This reverts commit e4b8735b9c4a885c4b79fb7e4d69c3e5645cbcf2.

* Revert "try 3 for all"

This reverts commit 060ba0e9e2d07f163c08b9a7d987fd31ae859606.

* spam quicker

* Revert "spam quicker"

This reverts commit 2db7d709b9c63ecd2bbfbd5abd91e39e1a2d3120.

* okay, always send it why not

* fix

* bring them back

* Revert "fix"

This reverts commit 05d9d293e45308d2aeca1ceda3dceac5d1d1f6c8.

* Revert "okay, always send it why not"

This reverts commit 09ed171aac6e4ff0400e42f76ff6651a66865362.

* separate thresholds between preglobal and global

* longer wait before sending

* shorter time but immediately resend

* quick

* new timeout

* about to cry

* Revert "about to cry"

This reverts commit eaea0eec60005a6bf6a2c5a405b20cc026f266d2.

* Revert "new timeout"

This reverts commit 6794575f09e1f9769429bf888536b20526dc01a3.

* Revert "quick"

This reverts commit 540eb2bf0a98851fa6ab8d9a480fe0912bf85c1b.

* Revert "shorter time but immediately resend"

This reverts commit a7b1203ddb4d67667f1ff8c9342da2bdafdf6aa5.

* Revert "longer wait before sending"

This reverts commit 74f80ecc0fdb091fb042750b8c7dc143b0121e05.

* same thing but another try

* no need

* round 3

* try 1.4

* lower!

* 1.2

* last try

* redo later

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
Validation
* Dongle ID: 
* Route: 
