### PR TITLE
Nissan: use MADS enabled status for LKAS HUD logic

### DIFF
--- a/opendbc/car/nissan/carcontroller.py
+++ b/opendbc/car/nissan/carcontroller.py
@@ -61,8 +61,8 @@ class CarController(CarControllerBase):
     # Below are the HUD messages. We copy the stock message and modify
     if self.CP.carFingerprint != CAR.NISSAN_ALTIMA:
       if self.frame % 2 == 0:
-        can_sends.append(nissancan.create_lkas_hud_msg(self.packer, CS.lkas_hud_msg, CC_SP.mads.enabled, hud_control.leftLaneVisible, hud_control.rightLaneVisible,
-                                                       hud_control.leftLaneDepart, hud_control.rightLaneDepart))
+        can_sends.append(nissancan.create_lkas_hud_msg(self.packer, CS.lkas_hud_msg, CC_SP.mads.enabled, hud_control.leftLaneVisible,
+                                                       hud_control.rightLaneVisible, hud_control.leftLaneDepart, hud_control.rightLaneDepart))
 
       if self.frame % 50 == 0:
         can_sends.append(nissancan.create_lkas_hud_info_msg(


### PR DESCRIPTION
Display the green steering-wheel icon on the hud whenever lat is active instead of when cc is active. This fixes the issue where there is no hud icon when MADS is enabled when cc is disabled.