### PR TITLE
Update values.py add CAR.HYUNDAI_TUCSON_4TH_GEN in non_essential_ecus

### DIFF
--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -807,7 +807,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
   non_essential_ecus={
     Ecu.abs: [CAR.HYUNDAI_PALISADE, CAR.HYUNDAI_SONATA, CAR.HYUNDAI_SANTA_FE_2022, CAR.KIA_K5_2021, CAR.HYUNDAI_ELANTRA_2021,
               CAR.HYUNDAI_SANTA_FE, CAR.HYUNDAI_KONA_EV_2022, CAR.HYUNDAI_KONA_EV, CAR.HYUNDAI_CUSTIN_1ST_GEN, CAR.KIA_SORENTO,
-              CAR.KIA_CEED, CAR.KIA_SELTOS],
+              CAR.KIA_CEED, CAR.KIA_SELTOS, CAR.HYUNDAI_TUCSON_4TH_GEN],
   },
   extra_ecus=[
     (Ecu.adas, 0x730, None),              # ADAS Driving ECU on platforms with LKA steering


### PR DESCRIPTION
Add CAR.HYUNDAI_TUCSON_4TH_GEN to the non_essential_ecus dictionary for Ecu.eps in opendbc/car/hyundai/values.py. This will allow the fingerprinting process to succeed even if the Ecu.eps is not present on all variants of the vehicle.

Dongle ID: b25afc8f8295c6b3
Route: https://useradmin.comma.ai/?onebox=b25afc8f8295c6b3%7C00000002--37279a9c0c
