### PR TITLE
Subaru Global: update neutral signal name

### DIFF
--- a/opendbc/sunnypilot/car/subaru/subarucan_ext.py
+++ b/opendbc/sunnypilot/car/subaru/subarucan_ext.py
@@ -26,7 +26,7 @@ def create_throttle(packer, CP, throttle_msg, send_resume):
       "CHECKSUM",
       "Signal1",
       "Engine_RPM",
-      "Signal2",
+      "Neutral",
       "Throttle_Pedal",
       "Throttle_Cruise",
       "Throttle_Combo",


### PR DESCRIPTION
fixes signal renaming `https://github.com/commaai/opendbc/pull/3048`

```
opendbc/sunnypilot/car/subaru/subarucan_ext.py:25
Exception: KeyError: 'Signal2'
  values = {s: throttle_msg[s] for s in [...]}
                       ^^^^^^^
  throttle_msg does NOT contain 'Signal2'
```
reported in https://community.sunnypilot.ai/t/complete-lkas-fault-on-21-forester-on-dev-branch/2831