### PR TITLE
Bolt Fingerprinting

### DIFF
--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -7,6 +7,7 @@ from opendbc.car.carlog import carlog
 from opendbc.car.structs import CarParams, CarParamsT
 from opendbc.car.fingerprints import eliminate_incompatible_cars, all_legacy_fingerprint_cars
 from opendbc.car.fw_versions import ObdCallback, get_fw_versions_ordered, get_present_ecus, match_fw_to_car
+from opendbc.car.gm.values import CAR as GM
 from opendbc.car.mock.values import CAR as MOCK
 from opendbc.car.values import BRANDS
 from opendbc.car.vin import get_vin, is_valid_vin, VIN_UNKNOWN
@@ -14,6 +15,33 @@ from opendbc.car.vin import get_vin, is_valid_vin, VIN_UNKNOWN
 from opendbc.sunnypilot.car.interfaces import setup_interfaces as sunnypilot_interfaces
 
 FRAME_FINGERPRINT = 100  # 1s
+
+
+def _classify_bolt_by_ascm_status(can_recv: CanRecvCallable) -> str:
+  # On some non-ACC Bolt EUV trims, 0x370 is present but always all-zero.
+  # ACC variants send non-zero fields (e.g. ACCGapLevel), so use this to split.
+  saw_ascm_status = False
+  frames = 0
+  max_frames = 40
+
+  while frames < max_frames:
+    can_packets = can_recv(wait_for_one=True)
+    if len(can_packets) == 0:
+      frames += 1
+      continue
+
+    for can_packet in can_packets:
+      for can in can_packet:
+        if can.src == 2 and can.address == 0x370:
+          saw_ascm_status = True
+          if any(can.dat):
+            return "acc"
+
+    frames += len(can_packets)
+
+  if saw_ascm_status:
+    return "non_acc_2nd_gen"
+  return "non_acc_1st_gen"
 
 
 def load_interfaces(brand_names):
@@ -139,6 +167,19 @@ def fingerprint(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_mu
     car_fingerprint = list(fw_candidates)[0]
     source = CarParams.FingerprintSource.fw
     exact_match = exact_fw_match
+
+  if car_fingerprint == GM.CHEVROLET_BOLT_EUV:
+    bolt_variant = _classify_bolt_by_ascm_status(can_recv)
+    if bolt_variant == "non_acc_2nd_gen":
+      carlog.warning("Detected all-zero ASCMActiveCruiseControlStatus (0x370); selecting non-ACC Bolt fingerprint")
+      car_fingerprint = GM.CHEVROLET_BOLT_NON_ACC_2ND_GEN
+      source = CarParams.FingerprintSource.can
+      exact_match = False
+    elif bolt_variant == "non_acc_1st_gen":
+      carlog.warning("ASCMActiveCruiseControlStatus (0x370) not seen; selecting 1st-gen non-ACC Bolt fingerprint")
+      car_fingerprint = GM.CHEVROLET_BOLT_NON_ACC_1ST_GEN
+      source = CarParams.FingerprintSource.can
+      exact_match = False
 
   if fixed_fingerprint:
     car_fingerprint = fixed_fingerprint

--- a/opendbc/sunnypilot/car/gm/fingerprint_ext.py
+++ b/opendbc/sunnypilot/car/gm/fingerprint_ext.py
@@ -1,0 +1,49 @@
+import time
+
+from opendbc.car.can_definitions import CanRecvCallable
+from opendbc.car.gm.values import CAR as GM
+
+
+def _classify_bolt_by_ascm_status(can_recv: CanRecvCallable) -> str:
+  # On some non-ACC Bolt EUV trims, 0x370 is present but always all-zero.
+  # ACC variants send non-zero fields (e.g. ACCGapLevel), so use this to split.
+  saw_ascm_status = False
+  saw_bus2_traffic = False
+  frames = 0
+  max_frames = 40
+  deadline = time.monotonic() + 1.0
+
+  while frames < max_frames and time.monotonic() < deadline:
+    can_packets = can_recv(wait_for_one=False)
+    if len(can_packets) == 0:
+      time.sleep(0.01)
+      continue
+
+    for can_packet in can_packets:
+      for can in can_packet:
+        if can.src == 2:
+          saw_bus2_traffic = True
+        if can.src == 2 and can.address == 0x370:
+          saw_ascm_status = True
+          if any(can.dat):
+            return "acc"
+
+    frames += len(can_packets)
+
+  if saw_ascm_status:
+    return "non_acc_2nd_gen"
+  if saw_bus2_traffic:
+    return "non_acc_1st_gen"
+  return "acc"
+
+
+def remap_candidate(candidate: str | None, can_recv: CanRecvCallable) -> str | None:
+  if candidate != GM.CHEVROLET_BOLT_EUV:
+    return candidate
+
+  bolt_variant = _classify_bolt_by_ascm_status(can_recv)
+  if bolt_variant == "non_acc_2nd_gen":
+    return GM.CHEVROLET_BOLT_NON_ACC_2ND_GEN
+  if bolt_variant == "non_acc_1st_gen":
+    return GM.CHEVROLET_BOLT_NON_ACC_1ST_GEN
+  return candidate

--- a/opendbc/sunnypilot/car/interfaces.py
+++ b/opendbc/sunnypilot/car/interfaces.py
@@ -90,6 +90,14 @@ def setup_interfaces(CI, CP: structs.CarParams, CP_SP: structs.CarParamsSP,
   _initialize_toyota(CP, CP_SP, params_dict)
 
 
+def remap_fingerprint_candidate(candidate: str | None, can_recv: CanRecvCallable) -> str | None:
+  if candidate is None:
+    return candidate
+
+  from opendbc.sunnypilot.car.gm.fingerprint_ext import remap_candidate as gm_remap_candidate
+  return gm_remap_candidate(candidate, can_recv)
+
+
 def _initialize_custom_longitudinal_tuning(CI, CP: structs.CarParams, CP_SP: structs.CarParamsSP,
                                            params_dict: dict[str, str]) -> None:
 


### PR DESCRIPTION
This allows all bolts to fingerprint correctly without needing to wait on Comma to release FPv3. 

0x370 contains ACC cruise messages 

On gen1 bolts, this message is absent
On gen2 bolts without ACC, this message is present but entirely zero'd out
On gen2 bolts with ACC, this message will contain data at all times (gap level, engaged status etc). 


You will not be able to properly distinguish 2017 without FPv3, but this will get you much closer and will at least make all cars work from the get go, even without 2017 specific lateral tuning. 