### PR TITLE
Rivian: long upgrade messages on bus 1

### DIFF
--- a/opendbc/car/rivian/interface.py
+++ b/opendbc/car/rivian/interface.py
@@ -40,7 +40,7 @@ class CarInterface(CarInterfaceBase):
   @staticmethod
   def _get_params_sp(stock_cp: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
                      car_fw: list[structs.CarParams.CarFw], alpha_long: bool, is_release_sp: bool, docs: bool) -> structs.CarParamsSP:
-    if 0x31a in fingerprint[5]:
+    if 0x131a in fingerprint[1]:
       ret.flags |= RivianFlagsSP.LONGITUDINAL_HARNESS_UPGRADE.value
       stock_cp.radarUnavailable = False
       stock_cp.enableBsm = True

--- a/opendbc/dbc/rivian_park_assist_can.dbc
+++ b/opendbc/dbc/rivian_park_assist_can.dbc
@@ -51,5 +51,23 @@ BO_ 848 BSM_BlindSpotIndicator: 4 XXX
  SG_ BSM_BlindSpotIndicator_Left : 29|2@0+ (1,0) [0|3] "" XXX
  SG_ BSM_BlindSpotIndicator_Right : 30|2@1+ (1,0) [0|3] "" XXX
 
+BO_ 4890 WheelButtons_Fwd: 7 XXX
+ SG_ LeftButton_ScrollClick : 19|2@0+ (1,0) [0|3] "" XXX
+ SG_ LeftButton_RightClick : 21|2@0+ (1,0) [0|3] "" XXX
+ SG_ LeftButton_LeftClick : 22|2@1+ (1,0) [0|3] "" XXX
+ SG_ LeftButton_Scroll : 31|8@0+ (1,0) [0|255] "" XXX
+ SG_ RightButton_ScrollClick : 35|2@0+ (1,0) [0|3] "" XXX
+ SG_ RightButton_RightClick : 37|2@0+ (1,0) [0|3] "" XXX
+ SG_ RightButton_LeftClick : 38|2@1+ (1,0) [0|3] "" XXX
+ SG_ RightButton_Scroll : 47|8@0+ (1,0) [0|255] "" XXX
+
+BO_ 4944 BSM_BlindSpotIndicator_Fwd: 4 XXX
+ SG_ BSM_BlindSpotIndicator_Checksum : 0|8@1+ (1,0) [0|255] "" XXX
+ SG_ BSM_BlindSpotIndicator_Counter : 11|4@0+ (1,0) [0|15] "" XXX
+ SG_ BSM_BlindSpotIndicator_Left : 29|2@0+ (1,0) [0|3] "" XXX
+ SG_ BSM_BlindSpotIndicator_Right : 30|2@1+ (1,0) [0|3] "" XXX
+
 VAL_ 848 BSM_BlindSpotIndicator_Left 0 "OFF" 1 "OBJECT_DETECTED" 2 "ACTIVE_WARNING" ;
 VAL_ 848 BSM_BlindSpotIndicator_Right 0 "OFF" 1 "OBJECT_DETECTED" 2 "ACTIVE_WARNING" ;
+VAL_ 4944 BSM_BlindSpotIndicator_Left 0 "OFF" 1 "OBJECT_DETECTED" 2 "ACTIVE_WARNING" ;
+VAL_ 4944 BSM_BlindSpotIndicator_Right 0 "OFF" 1 "OBJECT_DETECTED" 2 "ACTIVE_WARNING" ;

--- a/opendbc/sunnypilot/car/rivian/carstate_ext.py
+++ b/opendbc/sunnypilot/car/rivian/carstate_ext.py
@@ -42,15 +42,15 @@ class CarStateExt:
 
     if self.CP.openpilotLongitudinalControl:
       # distance scroll wheel
-      right_scroll = cp_park.vl["WheelButtons"]["RightButton_Scroll"]
+      right_scroll = cp_park.vl["WheelButtons_Fwd"]["RightButton_Scroll"]
       if right_scroll != 255:
         if self.distance_button != right_scroll:
           ret.buttonEvents = [structs.CarState.ButtonEvent(pressed=False, type=ButtonType.gapAdjustCruise)]
         self.distance_button = right_scroll
 
       # button logic for set-speed
-      self.increase_button = cp_park.vl["WheelButtons"]["RightButton_RightClick"] == 2
-      self.decrease_button = cp_park.vl["WheelButtons"]["RightButton_LeftClick"] == 2
+      self.increase_button = cp_park.vl["WheelButtons_Fwd"]["RightButton_RightClick"] == 2
+      self.decrease_button = cp_park.vl["WheelButtons_Fwd"]["RightButton_LeftClick"] == 2
 
       self.increase_counter = self.increase_counter + 1 if self.increase_button else 0
       self.decrease_counter = self.decrease_counter + 1 if self.decrease_button else 0
@@ -86,8 +86,8 @@ class CarStateExt:
       ret.cruiseState.speed = self.set_speed
 
     if self.CP.enableBsm:
-      ret.leftBlindspot = cp_park.vl["BSM_BlindSpotIndicator"]["BSM_BlindSpotIndicator_Left"] != 0
-      ret.rightBlindspot = cp_park.vl["BSM_BlindSpotIndicator"]["BSM_BlindSpotIndicator_Right"] != 0
+      ret.leftBlindspot = cp_park.vl["BSM_BlindSpotIndicator_Fwd"]["BSM_BlindSpotIndicator_Left"] != 0
+      ret.rightBlindspot = cp_park.vl["BSM_BlindSpotIndicator_Fwd"]["BSM_BlindSpotIndicator_Right"] != 0
 
   def update(self, ret: structs.CarState, can_parsers: dict[StrEnum, CANParser]) -> None:
     if self.CP_SP.flags & RivianFlagsSP.LONGITUDINAL_HARNESS_UPGRADE:
@@ -98,6 +98,6 @@ class CarStateExt:
     messages = {}
 
     if CP_SP.flags & RivianFlagsSP.LONGITUDINAL_HARNESS_UPGRADE:
-      messages[Bus.alt] = CANParser(DBC[CP.carFingerprint][Bus.alt], [], 5)
+      messages[Bus.alt] = CANParser(DBC[CP.carFingerprint][Bus.alt], [], 1)
 
     return messages


### PR DESCRIPTION
Depends on sunnypilot/sunnypilot#1712 
Moves the longitudinal harness upgrade from bus 5 (0x31a) to bus 1 (0x131a)