### PR TITLE
toyota: fix flipped BSM signals on Lexus LC

### DIFF
--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -176,8 +176,14 @@ class CarState(CarStateBase, CarStateExt):
     ret.espDisabled = cp.vl["ESP_CONTROL"]["TC_DISABLED"] != 0
 
     if self.CP.enableBsm:
-      ret.leftBlindspot = (cp.vl["BSM"]["L_ADJACENT"] == 1) or (cp.vl["BSM"]["L_APPROACHING"] == 1)
-      ret.rightBlindspot = (cp.vl["BSM"]["R_ADJACENT"] == 1) or (cp.vl["BSM"]["R_APPROACHING"] == 1)
+      l_bsm = (cp.vl["BSM"]["L_ADJACENT"] == 1) or (cp.vl["BSM"]["L_APPROACHING"] == 1)
+      r_bsm = (cp.vl["BSM"]["R_ADJACENT"] == 1) or (cp.vl["BSM"]["R_APPROACHING"] == 1)
+      if self.CP.flags & ToyotaFlags.FLIPPED_BSM.value:
+        ret.leftBlindspot = r_bsm
+        ret.rightBlindspot = l_bsm
+      else:
+        ret.leftBlindspot = l_bsm
+        ret.rightBlindspot = r_bsm
 
     if self.CP.carFingerprint != CAR.TOYOTA_PRIUS_V:
       self.lkas_hud = copy.copy(cp_cam.vl["LKAS_HUD"])

--- a/opendbc/car/toyota/values.py
+++ b/opendbc/car/toyota/values.py
@@ -74,6 +74,8 @@ class ToyotaFlags(IntFlag):
   # these cars can utilize 2.0 m/s^2
   RAISED_ACCEL_LIMIT = 1024
   SECOC = 2048
+  # BSM signals are swapped (L_ADJACENT/L_APPROACHING are actually right side and vice versa)
+  FLIPPED_BSM = 4096
 
   # deprecated flags
   # these cars are speculated to allow stop and go when the DSU is unplugged or disabled with sDSU
@@ -360,6 +362,7 @@ class CAR(Platforms):
   LEXUS_LC_TSS2 = ToyotaTSS2PlatformConfig(
     [ToyotaCarDocs("Lexus LC 2024-25")],
     CarSpecs(mass=4500. * CV.LB_TO_KG, wheelbase=2.87, steerRatio=13.0, tireStiffnessFactor=0.444),
+    flags=ToyotaFlags.FLIPPED_BSM,
   )
   LEXUS_RC = PlatformConfig(
     [ToyotaCarDocs("Lexus RC 2018-20")],


### PR DESCRIPTION
## Summary
- Add `FLIPPED_BSM` flag to `ToyotaFlags` for cars where BSM left/right CAN signals are swapped
- Set `FLIPPED_BSM` on `LEXUS_LC_TSS2` platform config
- Swap `leftBlindspot`/`rightBlindspot` assignment in `carstate.py` when the flag is set

## Problem
On my 2025 US-spec Lexus LC500, blind spot monitoring alerts are flipped. A vehicle on the left shows as a right-side alert on the Comma 3X, and the other way around. This also means lane change blocking fires for the wrong direction.

The CAN message `0x3F6` (BSM) has `L_ADJACENT`/`L_APPROACHING` signals that actually correspond to the right side on this car, and `R_ADJACENT`/`R_APPROACHING` for the left.

## Approach
Flag-based fix rather than changing the shared DBC, since the DBC represents the common Toyota wire format and this is a platform-specific quirk. The `FLIPPED_BSM` flag is reusable if other models turn out to have the same issue. There's an existing TODO in `interface.py` noting that C-HR and possibly region-specific variants may also need this.

## Test plan
- [ ] Independently verify BSM left/right alerts display on the correct side on a Lexus LC500 with Comma 3X (would appreciate more LC owners of different regions and MYs chiming in)
- [ ] Confirm lane change blocking triggers for the correct direction when BSM detects a vehicle
- [ ] Verify no regression on other TSS2 Toyota/Lexus vehicles (flag is only set on LEXUS_LC_TSS2)