### PR TITLE
feat(subaru): add LKAS button support for pre-global MADS

### DIFF
--- a/opendbc/dbc/generator/subaru/subaru_forester_2017.dbc
+++ b/opendbc/dbc/generator/subaru/subaru_forester_2017.dbc
@@ -7,6 +7,7 @@ BO_ 355 ES_DashStatus: 8 XXX
  SG_ Cruise_Set_Speed : 24|8@1+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 40|3@1+ (1,0) [0|7] "" XXX
  SG_ Brake : 43|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_State : 38|1@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 54|1@1+ (1,0) [0|1] "" XXX
  SG_ Far_Distance : 56|4@1+ (5,0) [0|75] "m" XXX
 

--- a/opendbc/sunnypilot/car/subaru/mads.py
+++ b/opendbc/sunnypilot/car/subaru/mads.py
@@ -18,6 +18,8 @@ ButtonType = structs.CarState.ButtonEvent.Type
 class MadsCarState(MadsCarStateBase):
   def __init__(self, CP: structs.CarParams, CP_SP: structs.CarParamsSP):
     super().__init__(CP, CP_SP)
+    self._prev_lkas_raw = None
+    self._initial_applied = False
 
   @staticmethod
   def create_lkas_button_events(cur_btn: int, prev_btn: int,
@@ -42,7 +44,33 @@ class MadsCarState(MadsCarStateBase):
     cp_cam = can_parsers[Bus.cam]
 
     self.prev_lkas_button = self.lkas_button
-    if not self.CP.flags & SubaruFlags.PREGLOBAL:
+    if self.CP.flags & SubaruFlags.PREGLOBAL:
+      # Pre-global Subarus don't have ES_LKAS_State. The LKAS button
+      # state is in ES_DashStatus byte4 bit6 as a latching toggle (0/1).
+      lkas_state = int(cp_cam.vl["ES_DashStatus"]["LKAS_State"])
+      if self._prev_lkas_raw is None:
+        # First read: record state, wait for cruise to be available
+        self._prev_lkas_raw = lkas_state
+        self.lkas_button = 0
+      elif not self._initial_applied:
+        # Track LKAS changes during boot (user may press button early)
+        self._prev_lkas_raw = lkas_state
+        if ret.cruiseState.available:
+          # Cruise is ready. Apply current LKAS state to auto-enable
+          # MADS if LKAS was left on, matching the dash indicator.
+          self.lkas_button = lkas_state
+          self._initial_applied = True
+        else:
+          self.lkas_button = 0
+      else:
+        # Normal operation: convert latching toggle to pulse so
+        # create_lkas_button_events sees 0->1->0 per press.
+        if lkas_state != self._prev_lkas_raw:
+          self.lkas_button = 1
+        else:
+          self.lkas_button = 0
+        self._prev_lkas_raw = lkas_state
+    else:
       self.lkas_button = cp_cam.vl["ES_LKAS_State"]["LKAS_Dash_State"]
 
     ret.buttonEvents = self.create_lkas_button_events(self.lkas_button, self.prev_lkas_button, {1: ButtonType.lkas})

--- a/opendbc/sunnypilot/car/subaru/mads.py
+++ b/opendbc/sunnypilot/car/subaru/mads.py
@@ -47,7 +47,9 @@ class MadsCarState(MadsCarStateBase):
     if self.CP.flags & SubaruFlags.PREGLOBAL:
       # Pre-global Subarus don't have ES_LKAS_State. The LKAS button
       # state is in ES_DashStatus byte4 bit6 as a latching toggle (0/1).
-      lkas_state = int(cp_cam.vl["ES_DashStatus"]["LKAS_State"])
+      # LKAS_State is currently only defined in the Forester pre-global DBC.
+      # Fall back to 0 for other pre-global models until verified.
+      lkas_state = int(cp_cam.vl["ES_DashStatus"].get("LKAS_State", 0))
       if self._prev_lkas_raw is None:
         # First read: record state, wait for cruise to be available
         self._prev_lkas_raw = lkas_state


### PR DESCRIPTION
Pre-global Subarus don't have ES_LKAS_State, so the LKAS button was never wired into MADS. This meant MADS lateral control could not be toggled via the physical LKAS button on the steering wheel. The LKAS button state is available in ES_DashStatus byte4 bit6 as a latching toggle (0=off, 1=on). This persists across ignition cycles.

This PR adds an LKAS_State signal to the pre-global Forester DBC and read it in the MADS carstate. The latching toggle is converted to a pulse so create_lkas_button_events generates one event per physical press. On boot, the initial LKAS state is applied once cruiseState becomes available, auto-enabling MADS if the driver left LKAS on when the car was last turned off.

Tested on 2018 Subaru Forester (pre-global) with sunnypilot 2026.001.000.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID: 61b5a4087aa4464f
* Route: 61b5a4087aa4464f/00000038--3de930fa7b/0
