### PR TITLE
mazda: add alpha longitudinal support

### DIFF
--- a/opendbc/car/mazda/carcontroller.py
+++ b/opendbc/car/mazda/carcontroller.py
@@ -192,7 +192,7 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
         long_active = CC.longActive
         lead_visible = CC.hudControl.leadVisible
         can_sends.extend(create_longitudinal_messages(RADAR_BUS, accel, self.long_counter,
-                                                      long_active, lead_visible, CS.out.standstill,
+                                                      long_active, lead_visible,
                                                       hold_request=crz_info_hold_request,
                                                       crz_ctrl_hold_request=stop_go_request,
                                                       hold_latched=hold_latched,

--- a/opendbc/car/mazda/carcontroller.py
+++ b/opendbc/car/mazda/carcontroller.py
@@ -1,13 +1,24 @@
 from opendbc.can import CANPacker
-from opendbc.car import Bus, structs
+from opendbc.car import Bus, DT_CTRL, structs
 from opendbc.car.lateral import apply_driver_steer_torque_limits
 from opendbc.car.interfaces import CarControllerBase
+from opendbc.car.mazda.longitudinal import LONG_COMMAND_STEP, NEAR_STOP_ENTRY_SPEED, RADAR_BUS, TESTER_PRESENT_STEP, \
+                                           create_longitudinal_messages, create_radar_tester_present, \
+                                           hold_brake_accel, hold_latched_accel, near_stop_brake_accel
 from opendbc.car.mazda import mazdacan
 from opendbc.car.mazda.values import CarControllerParams, Buttons
 
 from opendbc.sunnypilot.car.mazda.icbm import IntelligentCruiseButtonManagementInterface
 
 VisualAlert = structs.CarControl.HUDControl.VisualAlert
+LongCtrlState = structs.CarControl.Actuators.LongControlState
+
+CRZ_CTRL_LATCH_FRAMES = int(round(2.0 / DT_CTRL))
+CRZ_CTRL_PASSIVE_FRAMES = int(round(9.6 / DT_CTRL))
+CRZ_CTRL_RESUME_REACTIVATE_FRAMES = int(round(0.08 / DT_CTRL))
+CRZ_INFO_RESUME_PHASE_FRAMES = int(round(0.20 / DT_CTRL))
+HOLD_REQUEST_FRAMES = int(round(6.0 / DT_CTRL))
+RESUME_RELEASE_FRAMES = int(round(0.5 / DT_CTRL))
 
 
 class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterface):
@@ -17,6 +28,15 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
     self.apply_torque_last = 0
     self.packer = CANPacker(dbc_names[Bus.pt])
     self.brake_counter = 0
+    self.long_counter = 0
+    self.standstill_hold_frames = 0
+    self.stop_intent_latched = False
+    self.resume_release_frames = 0
+    self.resume_crz_latched_frames = 0
+    self.resume_phase_frames = 0
+    self.resume_ctrl_active_prev = False
+    self.virtual_resume_sent_latched = False
+    self.resume_button_prev = False
 
   def update(self, CC, CC_SP, CS, now_nanos):
     can_sends = []
@@ -29,24 +49,162 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
       apply_torque = apply_driver_steer_torque_limits(new_torque, self.apply_torque_last,
                                                       CS.out.steeringTorque, CarControllerParams)
 
-    if CC.cruiseControl.cancel:
-      # If brake is pressed, let us wait >70ms before trying to disable crz to avoid
-      # a race condition with the stock system, where the second cancel from openpilot
-      # will disable the crz 'main on'. crz ctrl msg runs at 50hz. 70ms allows us to
-      # read 3 messages and most likely sync state before we attempt cancel.
-      self.brake_counter = self.brake_counter + 1
-      if self.frame % 10 == 0 and not (CS.out.brakePressed and self.brake_counter < 7):
-        # Cancel Stock ACC if it's enabled while OP is disengaged
-        # Send at a rate of 10hz until we sync with stock ACC state
-        can_sends.append(mazdacan.create_button_cmd(self.packer, self.CP, CS.crz_btns_counter, Buttons.CANCEL))
+    virtual_resume_sent = False
+    if not self.CP.openpilotLongitudinalControl:
+      if CC.cruiseControl.cancel:
+        # If brake is pressed, let us wait >70ms before trying to disable crz to avoid
+        # a race condition with the stock system, where the second cancel from openpilot
+        # will disable the crz 'main on'. crz ctrl msg runs at 50hz. 70ms allows us to
+        # read 3 messages and most likely sync state before we attempt cancel.
+        self.brake_counter = self.brake_counter + 1
+        if self.frame % 10 == 0 and not (CS.out.brakePressed and self.brake_counter < 7):
+          # Cancel Stock ACC if it's enabled while OP is disengaged
+          # Send at a rate of 10hz until we sync with stock ACC state
+          can_sends.append(mazdacan.create_button_cmd(self.packer, self.CP, CS.crz_btns_counter, Buttons.CANCEL))
+      else:
+        self.brake_counter = 0
+        if CC.cruiseControl.resume and self.frame % 5 == 0:
+          # Mazda Stop and Go requires a RES button (or gas) press if the car stops more than 3 seconds
+          # Send Resume button when planner wants car to move
+          can_sends.append(mazdacan.create_button_cmd(self.packer, self.CP, CS.crz_btns_counter, Buttons.RESUME))
     else:
       self.brake_counter = 0
-      if CC.cruiseControl.resume and self.frame % 5 == 0:
-        # Mazda Stop and Go requires a RES button (or gas) press if the car stops more than 3 seconds
-        # Send Resume button when planner wants car to move
+      if CS.out.standstill and CC.cruiseControl.resume and self.frame % 5 == 0:
         can_sends.append(mazdacan.create_button_cmd(self.packer, self.CP, CS.crz_btns_counter, Buttons.RESUME))
+        virtual_resume_sent = True
 
     self.apply_torque_last = apply_torque
+
+    if self.CP.openpilotLongitudinalControl:
+      stopping = CC.actuators.longControlState == LongCtrlState.stopping
+      starting = CC.actuators.longControlState == LongCtrlState.starting
+      # Do not treat tiny positive low-speed PID noise as a real restart
+      # request. Only the explicit upstream starting phase should release the
+      # synthetic HOLD clamp automatically.
+      restart_requested = starting
+      # Physical wheel RES survives radar suppression on CRZ_BTNS. For virtual
+      # RES, do not start the synthetic unlatch path until the first RES frame
+      # has actually been transmitted on the bus.
+      if not CC.cruiseControl.resume or not CS.out.standstill:
+        self.virtual_resume_sent_latched = False
+      elif virtual_resume_sent:
+        self.virtual_resume_sent_latched = True
+      physical_resume_requested = bool(CS.accel_button)
+      virtual_resume_requested = CC.cruiseControl.resume and self.virtual_resume_sent_latched
+      effective_resume_requested = False
+      release_hold_requested = False
+      release_brake = False
+      if not CC.longActive:
+        self.standstill_hold_frames = 0
+        self.stop_intent_latched = False
+        self.resume_release_frames = 0
+        self.resume_crz_latched_frames = 0
+        self.resume_phase_frames = 0
+        self.resume_ctrl_active_prev = False
+        self.virtual_resume_sent_latched = False
+      else:
+        if stopping:
+          self.stop_intent_latched = True
+
+        hold_latched_ready = CS.out.standstill and self.standstill_hold_frames > HOLD_REQUEST_FRAMES
+        # A physical wheel RES should always be able to ask Mazda to leave
+        # HOLD. For virtual RES, require that we have both actually sent a RES
+        # frame and reached the latched-hold phase so a transient shouldStop
+        # flicker cannot prematurely release the synthetic hold.
+        physical_resume_unlatch_requested = CS.out.standstill and physical_resume_requested and (not stopping or hold_latched_ready)
+        virtual_resume_unlatch_requested = CS.out.standstill and virtual_resume_requested and hold_latched_ready
+        resume_unlatch_requested = physical_resume_unlatch_requested or virtual_resume_unlatch_requested
+        effective_resume_requested = resume_unlatch_requested
+        resume_rising_edge = effective_resume_requested and not self.resume_button_prev
+        release_brake = self.resume_release_frames > 0
+        base_release_hold_requested = CC.cruiseControl.override or CS.out.gasPressed or restart_requested or release_brake
+
+        if CS.out.standstill and self.stop_intent_latched and not base_release_hold_requested:
+          self.standstill_hold_frames += 1
+        else:
+          self.standstill_hold_frames = 0
+
+        if CS.out.standstill and not base_release_hold_requested and resume_rising_edge and self.standstill_hold_frames >= CRZ_CTRL_PASSIVE_FRAMES:
+          # Stock briefly re-enables ACC in the latched-hold profile when RES is
+          # first pressed, then drops back into the active stop-go profile.
+          self.resume_crz_latched_frames = CRZ_CTRL_RESUME_REACTIVATE_FRAMES
+        elif self.resume_crz_latched_frames > 0:
+          self.resume_crz_latched_frames -= 1
+
+        if resume_unlatch_requested:
+          self.resume_release_frames = RESUME_RELEASE_FRAMES
+        elif self.resume_release_frames > 0:
+          self.resume_release_frames -= 1
+
+        release_brake = self.resume_release_frames > 0
+        release_hold_requested = base_release_hold_requested or resume_unlatch_requested or release_brake
+
+        if release_hold_requested or (not CS.out.standstill and not stopping and CS.out.vEgo > NEAR_STOP_ENTRY_SPEED):
+          self.stop_intent_latched = False
+
+      # Only enter Mazda's synthetic stop-go/HOLD path when upstream has
+      # actually committed to a stop. Once that happens, keep the stop intent
+      # latched through the standstill/HOLD phases until a real restart or
+      # driver override releases it.
+      # A virtual RES press should happen while Mazda still sees the passive
+      # stop-go hold state. Only release that synthetic hold once the car is
+      # actually starting to move or the driver overrides with gas.
+      stop_go_request = CC.longActive and self.stop_intent_latched and not release_hold_requested
+      standstill_hold_request = stop_go_request and CS.out.standstill
+      hold_latched = standstill_hold_request and self.standstill_hold_frames > HOLD_REQUEST_FRAMES
+      brake_release_requested = release_hold_requested or effective_resume_requested
+
+      crz_hold_latched = standstill_hold_request and self.standstill_hold_frames >= CRZ_CTRL_LATCH_FRAMES and \
+                         (not effective_resume_requested or self.resume_crz_latched_frames > 0)
+      # Stock resumes from passive hold by re-enabling ACC while the RES press
+      # is active, instead of staying indefinitely in the passive-hold substate.
+      crz_hold_passive = standstill_hold_request and self.standstill_hold_frames >= CRZ_CTRL_PASSIVE_FRAMES and not effective_resume_requested
+      release_brake = self.resume_release_frames > 0
+      crz_ctrl_resume_active = release_brake and CS.out.vEgo < self.CP.vEgoStarting and not crz_hold_latched and not crz_hold_passive
+      if crz_ctrl_resume_active:
+        if not self.resume_ctrl_active_prev:
+          self.resume_phase_frames = CRZ_INFO_RESUME_PHASE_FRAMES
+        elif self.resume_phase_frames > 0:
+          self.resume_phase_frames -= 1
+      else:
+        self.resume_phase_frames = 0
+      crz_info_resume_unlatching = crz_ctrl_resume_active and self.resume_phase_frames > 0
+      self.resume_ctrl_active_prev = crz_ctrl_resume_active
+      # Keep CRZ_INFO stop bits cleared through the whole synthetic brake-release
+      # window. Otherwise Mazda sees positive accel while we still advertise an
+      # active stop, which shows up in the logs as a failed restart handoff.
+      crz_info_hold_request = stop_go_request and not (brake_release_requested or release_brake)
+
+      accel = 0.0
+      if CC.longActive:
+        accel = CC.actuators.accel
+        if release_brake:
+          accel = max(accel, 0.0)
+        elif CS.out.standstill:
+          accel = hold_latched_accel() if hold_latched else hold_brake_accel()
+        elif self.stop_intent_latched and not release_hold_requested and (stopping or CS.out.vEgo < NEAR_STOP_ENTRY_SPEED):
+          accel = min(accel, near_stop_brake_accel(CS.out.vEgo))
+
+      if self.frame % TESTER_PRESENT_STEP == 0:
+        can_sends.append(create_radar_tester_present(RADAR_BUS))
+
+      if self.frame % LONG_COMMAND_STEP == 0:
+        long_active = CC.longActive
+        lead_visible = CC.hudControl.leadVisible
+        can_sends.extend(create_longitudinal_messages(RADAR_BUS, accel, self.long_counter,
+                                                      long_active, lead_visible, CS.out.standstill,
+                                                      hold_request=crz_info_hold_request,
+                                                      crz_ctrl_hold_request=stop_go_request,
+                                                      hold_latched=hold_latched,
+                                                      crz_hold_latched=crz_hold_latched,
+                                                      crz_hold_passive=crz_hold_passive,
+                                                      crz_resume_active=crz_ctrl_resume_active,
+                                                      crz_info_resume_unlatching=crz_info_resume_unlatching,
+                                                      v_ego=CS.out.vEgo))
+        self.long_counter = (self.long_counter + 1) % 16
+      self.resume_button_prev = effective_resume_requested
+    else:
+      self.resume_button_prev = False
 
     # send HUD alerts
     if self.frame % 50 == 0:

--- a/opendbc/car/mazda/carstate.py
+++ b/opendbc/car/mazda/carstate.py
@@ -21,6 +21,16 @@ class CarState(CarStateBase):
     self.distance_button = 0
     self.accel_button = 0
     self.decel_button = 0
+    self.cancel_button = 0
+    self.main_button = 0
+
+  def update_button_enable(self, buttonEvents: list[structs.CarState.ButtonEvent]):
+    if not self.CP.pcmCruise:
+      for b in buttonEvents:
+        if (b.type == ButtonType.accelCruise and b.pressed) or \
+           (b.type == ButtonType.decelCruise and not b.pressed):
+          return True
+    return False
 
   def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
@@ -80,12 +90,48 @@ class CarState(CarStateBase):
     else:
       self.lkas_allowed_speed = True
 
-    # TODO: the signal used for available seems to be the adaptive cruise signal, instead of the main on
-    #       it should be used for carState.cruiseState.nonAdaptive instead
-    ret.cruiseState.available = cp.vl["CRZ_CTRL"]["CRZ_AVAILABLE"] == 1
-    ret.cruiseState.enabled = cp.vl["CRZ_CTRL"]["CRZ_ACTIVE"] == 1
+    # cruise control button events: main/cancel survive radar suppression on
+    # CRZ_BTNS as MODE_X+MODE_Y and CAN_OFF respectively.
+    prev_distance_button = self.distance_button
+    prev_accel_button = self.accel_button
+    prev_decel_button = self.decel_button
+    prev_cancel_button = self.cancel_button
+    prev_main_button = self.main_button
+    self.distance_button = cp.vl["CRZ_BTNS"]["DISTANCE_LESS"]
+    self.accel_button = cp.vl["CRZ_BTNS"]["RES"]
+    self.decel_button = cp.vl["CRZ_BTNS"]["SET_M"]
+    self.cancel_button = cp.vl["CRZ_BTNS"]["CAN_OFF"]
+    self.main_button = int(cp.vl["CRZ_BTNS"]["MODE_X"] == 1 and cp.vl["CRZ_BTNS"]["MODE_Y"] == 1)
+
+    ret.buttonEvents = [
+      *create_button_events(self.distance_button, prev_distance_button, {1: ButtonType.gapAdjustCruise}),
+      *create_button_events(self.accel_button, prev_accel_button, {1: ButtonType.accelCruise}),
+      *create_button_events(self.decel_button, prev_decel_button, {1: ButtonType.decelCruise}),
+      *create_button_events(self.cancel_button, prev_cancel_button, {1: ButtonType.cancel}),
+      *create_button_events(self.main_button, prev_main_button, {1: ButtonType.mainCruise}),
+    ]
+
+    # In alpha-long mode the radar-owned CRZ_CTRL frame is intentionally
+    # suppressed, so do not subscribe to it here or card will mark CAN invalid
+    # once the stock frame times out after takeover. On Mazda, PEDALS.ACC_OFF
+    # is asserted while MRCC is armed but not actively controlling, and
+    # PEDALS.ACC_ACTIVE is asserted once stock ACC takes over. Treat either
+    # state as cruise available so MADS does not interpret a stock ACC engage
+    # as the MRCC main switch turning off.
+    if self.CP.openpilotLongitudinalControl:
+      acc_armed = cp.vl["PEDALS"]["ACC_OFF"] == 1
+      acc_active = cp.vl["PEDALS"]["ACC_ACTIVE"] == 1
+      ret.cruiseState.available = acc_armed or acc_active
+      ret.cruiseState.enabled = acc_active
+    else:
+      # TODO: the signal used for available seems to be the adaptive cruise signal,
+      # instead of the main on. It should be used for
+      # carState.cruiseState.nonAdaptive instead.
+      ret.cruiseState.available = cp.vl["CRZ_CTRL"]["CRZ_AVAILABLE"] == 1
+      ret.cruiseState.enabled = cp.vl["CRZ_CTRL"]["CRZ_ACTIVE"] == 1
     ret.cruiseState.standstill = cp.vl["PEDALS"]["STANDSTILL"] == 1
     ret.cruiseState.speed = cp.vl["CRZ_EVENTS"]["CRZ_SPEED"] * CV.KPH_TO_MS
+    ret.cruiseState.speedCluster = ret.cruiseState.speed
 
     # stock lkas should be on
     # TODO: is this needed?
@@ -111,20 +157,6 @@ class CarState(CarStateBase):
     self.cam_lkas = cp_cam.vl["CAM_LKAS"]
     self.cam_laneinfo = cp_cam.vl["CAM_LANEINFO"]
     ret.steerFaultPermanent = cp_cam.vl["CAM_LKAS"]["ERR_BIT_1"] == 1
-
-    # cruise control button events: distance, inc, and dec
-    prev_distance_button = self.distance_button
-    prev_accel_button = self.accel_button
-    prev_decel_button = self.decel_button
-    self.distance_button = cp.vl["CRZ_BTNS"]["DISTANCE_LESS"]
-    self.accel_button = cp.vl["CRZ_BTNS"]["RES"]
-    self.decel_button = cp.vl["CRZ_BTNS"]["SET_M"]
-
-    ret.buttonEvents = [
-      *create_button_events(self.distance_button, prev_distance_button, {1: ButtonType.gapAdjustCruise}),
-      *create_button_events(self.accel_button, prev_accel_button, {1: ButtonType.accelCruise}),
-      *create_button_events(self.decel_button, prev_decel_button, {1: ButtonType.decelCruise}),
-    ]
 
     return ret, ret_sp
 

--- a/opendbc/car/mazda/interface.py
+++ b/opendbc/car/mazda/interface.py
@@ -4,7 +4,10 @@ from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.interfaces import CarInterfaceBase
 from opendbc.car.mazda.carcontroller import CarController
 from opendbc.car.mazda.carstate import CarState
+from opendbc.car.mazda.longitudinal import enter_radar_programming_session
 from opendbc.car.mazda.values import CAR, LKAS_LIMITS
+
+MAZDA_LONG_SAFETY_PARAM = 1
 
 
 class CarInterface(CarInterfaceBase):
@@ -14,7 +17,14 @@ class CarInterface(CarInterfaceBase):
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, alpha_long, is_release, docs) -> structs.CarParams:
     ret.brand = "mazda"
-    ret.safetyConfigs = [get_safety_config(structs.CarParams.SafetyModel.mazda)]
+    ret.alphaLongitudinalAvailable = candidate == CAR.MAZDA_CX5_2022
+    ret.openpilotLongitudinalControl = alpha_long and ret.alphaLongitudinalAvailable
+    # Mazda-long still engages on the stock ACC-active transition even though
+    # we suppress the radar-owned CRZ_CTRL path and synthesize replacement
+    # longitudinal messages.
+    ret.pcmCruise = True
+    ret.safetyConfigs = [get_safety_config(structs.CarParams.SafetyModel.mazda,
+                                           MAZDA_LONG_SAFETY_PARAM if ret.openpilotLongitudinalControl else None)]
     ret.radarUnavailable = True
 
     ret.dashcamOnly = candidate not in (CAR.MAZDA_CX5_2022, CAR.MAZDA_CX9_2021)
@@ -27,6 +37,17 @@ class CarInterface(CarInterfaceBase):
     if candidate not in (CAR.MAZDA_CX5_2022,):
       ret.minSteerSpeed = LKAS_LIMITS.DISABLE_SPEED * CV.KPH_TO_MS
 
+    if ret.openpilotLongitudinalControl:
+      ret.startingState = True
+      ret.startAccel = 1.2
+      ret.vEgoStarting = 0.15
+      ret.vEgoStopping = 0.5
+      ret.longitudinalActuatorDelay = 0.36
+      ret.longitudinalTuning.kpBP = [0., 5., 20.]
+      ret.longitudinalTuning.kpV = [1.2, 1.0, 0.8]
+      ret.longitudinalTuning.kiBP = [0., 5., 20.]
+      ret.longitudinalTuning.kiV = [0.18, 0.12, 0.08]
+
     ret.centerToFront = ret.wheelbase * 0.41
 
     return ret
@@ -37,3 +58,16 @@ class CarInterface(CarInterfaceBase):
     ret.intelligentCruiseButtonManagementAvailable = True
 
     return ret
+
+  @staticmethod
+  def init(CP, CP_SP, can_recv, can_send):
+    if CP.openpilotLongitudinalControl:
+      enter_radar_programming_session(can_recv, can_send)
+
+  @staticmethod
+  def deinit(CP, can_recv, can_send):
+    if CP.openpilotLongitudinalControl:
+      # Mazda's radar faults if we explicitly request the default/active session
+      # on teardown. Exiting cleanly is just stopping tester present and letting
+      # the radar time out back to stock behavior on its own.
+      return

--- a/opendbc/car/mazda/longitudinal.py
+++ b/opendbc/car/mazda/longitudinal.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from opendbc.can.dbc import DBC
+from opendbc.can.packer import set_value
+from opendbc.car import make_tester_present_msg, uds
+from opendbc.car.can_definitions import CanData
+from opendbc.car.carlog import carlog
+from opendbc.car.isotp_parallel_query import IsoTpParallelQuery
+
+
+MAZDA_LONG_DBC = DBC("mazda_2017")
+
+RADAR_ADDR = 0x764
+RADAR_BUS = 0
+
+CRZ_INFO_ADDR = 0x21B
+CRZ_CTRL_ADDR = 0x21C
+
+CRZ_INFO_TEMPLATE = bytes.fromhex("01ffe20006800000")
+
+LONG_COMMAND_STEP = 2
+TESTER_PRESENT_STEP = 50
+
+ACCEL_CMD_MAX = 2000.0
+ACCEL_CMD_MIN = -2000.0
+HOLD_BRAKE_CMD_TARGET = -1024.0
+HOLD_LATCHED_CMD_TARGET = -1.0
+NEAR_STOP_BRAKE_CMD_TARGET = -750.0
+NEAR_STOP_ENTRY_SPEED = 1.0
+ACTIVE_STOP_CHECKSUM_BIAS = 0x04
+
+# Stock Mazda longitudinal is not using one global raw-command scale across all
+# speeds. Keep more authority at low/mid speed, and soften the map at highway
+# speed where the single-scale version feels jerky.
+ACCEL_SCALE_UP_BP = (0.0, 4.2, 11.1, 22.2)
+ACCEL_SCALE_UP_V = (1000.0, 1000.0, 950.0, 800.0)
+ACCEL_SCALE_DOWN_BP = (0.0, 1.4, 5.6, 22.2)
+ACCEL_SCALE_DOWN_V = (1200.0, 1000.0, 925.0, 950.0)
+
+
+class MazdaLongitudinalProfile(str, Enum):
+  STANDBY = "standby"
+  ENGAGED_CRUISE = "engaged_cruise"
+  ENGAGED_FOLLOW = "engaged_follow"
+  STOP_GO_HOLD = "stop_go_hold"
+  STOP_GO_HOLD_LATCHED = "stop_go_hold_latched"
+
+
+CRZ_CTRL_TEMPLATES: dict[MazdaLongitudinalProfile, bytes] = {
+  MazdaLongitudinalProfile.STANDBY: bytes.fromhex("02010b0000000000"),
+  MazdaLongitudinalProfile.ENGAGED_CRUISE: bytes.fromhex("0a018b2000001000"),
+  MazdaLongitudinalProfile.ENGAGED_FOLLOW: bytes.fromhex("0a018b4000001000"),
+  MazdaLongitudinalProfile.STOP_GO_HOLD: bytes.fromhex("0a018b6000001000"),
+  MazdaLongitudinalProfile.STOP_GO_HOLD_LATCHED: bytes.fromhex("0a018b8000001000"),
+}
+
+
+def _get_signal(message_name: str, signal_name: str):
+  return MAZDA_LONG_DBC.name_to_msg[message_name].sigs[signal_name]
+
+
+def _patch_signal(message_name: str, raw: bytes, signal_name: str, value: float) -> bytes:
+  sig = _get_signal(message_name, signal_name)
+  encoded = int(round((value - sig.offset) / sig.factor))
+  if encoded < 0:
+    encoded = (1 << sig.size) + encoded
+
+  dat = bytearray(raw)
+  set_value(dat, sig, encoded)
+  return bytes(dat)
+
+
+def _compute_inverted_sum_checksum(raw: bytes, checksum_index: int = 7) -> int:
+  return (0xFF - (sum(raw[i] for i in range(len(raw)) if i != checksum_index) & 0xFF)) & 0xFF
+
+
+def _update_crz_info_checksum(raw: bytes, bias: int = 0) -> bytes:
+  dat = bytearray(raw)
+  dat[7] = (_compute_inverted_sum_checksum(dat) + bias) & 0xFF
+  return bytes(dat)
+
+
+def clip(value: float, lower: float, upper: float) -> float:
+  return min(max(value, lower), upper)
+
+
+def _interp_scale(v_ego: float, bp: tuple[float, ...], values: tuple[float, ...]) -> float:
+  if v_ego <= bp[0]:
+    return values[0]
+  if v_ego >= bp[-1]:
+    return values[-1]
+
+  for i in range(1, len(bp)):
+    if v_ego <= bp[i]:
+      x0, x1 = bp[i - 1], bp[i]
+      y0, y1 = values[i - 1], values[i]
+      ratio = (v_ego - x0) / (x1 - x0)
+      return y0 + (y1 - y0) * ratio
+
+  return values[-1]
+
+
+def accel_to_accel_cmd(accel: float, v_ego: float) -> int:
+  scale = _interp_scale(v_ego, ACCEL_SCALE_UP_BP, ACCEL_SCALE_UP_V) if accel >= 0.0 else _interp_scale(v_ego, ACCEL_SCALE_DOWN_BP, ACCEL_SCALE_DOWN_V)
+  return int(round(clip(accel * scale, ACCEL_CMD_MIN, ACCEL_CMD_MAX)))
+
+
+def hold_brake_accel() -> float:
+  # Stock HOLD keeps a strong negative CRZ_INFO command alive through the
+  # active stop/hold phase until the chassis hold latch takes over.
+  # Keep the raw target approximately constant as scales change.
+  return HOLD_BRAKE_CMD_TARGET / ACCEL_SCALE_DOWN_V[0]
+
+
+def hold_latched_accel() -> float:
+  # Once the chassis hold latch takes over, stock CRZ_INFO.ACCEL_CMD relaxes
+  # back near zero and the stop bits clear.
+  return HOLD_LATCHED_CMD_TARGET / ACCEL_SCALE_DOWN_V[0]
+
+
+def near_stop_brake_accel(v_ego: float) -> float:
+  # Stock stop-to-hold ramps into the final HOLD brake command before true
+  # standstill, rather than waiting until the speed bit drops to zero.
+  ratio = clip(v_ego / NEAR_STOP_ENTRY_SPEED, 0.0, 1.0)
+  target = HOLD_BRAKE_CMD_TARGET + (NEAR_STOP_BRAKE_CMD_TARGET - HOLD_BRAKE_CMD_TARGET) * ratio
+  return target / ACCEL_SCALE_DOWN_V[0]
+
+
+def build_crz_info(accel: float, counter: int, long_active: bool, hold_request: bool, v_ego: float,
+                   hold_latched: bool = False, acc_set_allowed: bool = True,
+                   resume_unlatching: bool = False) -> bytes:
+  stopping_active = hold_request and not hold_latched
+  raw = _patch_signal("CRZ_INFO", CRZ_INFO_TEMPLATE, "ACCEL_CMD", accel_to_accel_cmd(accel, v_ego))
+  raw = _patch_signal("CRZ_INFO", raw, "ACC_ACTIVE", int(long_active))
+  raw = _patch_signal("CRZ_INFO", raw, "ACC_SET_ALLOWED", int(acc_set_allowed))
+  raw = _patch_signal("CRZ_INFO", raw, "CRZ_ENDED", 0)
+  raw = _patch_signal("CRZ_INFO", raw, "STOPPING_MAYBE", int(stopping_active))
+  raw = _patch_signal("CRZ_INFO", raw, "STOPPING_MAYBE2", int(stopping_active))
+  raw = _patch_signal("CRZ_INFO", raw, "RESUME_UNLATCHING_MAYBE", int(resume_unlatching))
+  raw = _patch_signal("CRZ_INFO", raw, "CTR1", counter % 16)
+  checksum_bias = ACTIVE_STOP_CHECKSUM_BIAS if stopping_active else 0
+  return _update_crz_info_checksum(raw, bias=checksum_bias)
+
+
+def select_profile(long_active: bool, lead_visible: bool, hold_request: bool,
+                   crz_hold_latched: bool) -> MazdaLongitudinalProfile:
+  if not long_active:
+    return MazdaLongitudinalProfile.STANDBY
+  if hold_request and crz_hold_latched:
+    return MazdaLongitudinalProfile.STOP_GO_HOLD_LATCHED
+  if hold_request:
+    return MazdaLongitudinalProfile.STOP_GO_HOLD
+  if lead_visible:
+    return MazdaLongitudinalProfile.ENGAGED_FOLLOW
+  return MazdaLongitudinalProfile.ENGAGED_CRUISE
+
+
+def build_crz_ctrl(long_active: bool, lead_visible: bool, hold_request: bool, hold_latched: bool,
+                   crz_hold_latched: bool = False, crz_hold_passive: bool = False,
+                   crz_resume_active: bool = False) -> bytes:
+  # Stock stop-and-go progresses through multiple CRZ_CTRL stop phases. Mirror
+  # that sequence so the synthetic path keeps the same latch states as stock.
+  lead_visible = lead_visible or hold_request or hold_latched or crz_hold_latched or crz_hold_passive
+  raw = CRZ_CTRL_TEMPLATES[select_profile(long_active, lead_visible, hold_request, crz_hold_latched)]
+  raw = _patch_signal("CRZ_CTRL", raw, "CRZ_ACTIVE", int(long_active))
+  raw = _patch_signal("CRZ_CTRL", raw, "ACC_ACTIVE_2", int(long_active and not crz_hold_passive))
+  raw = _patch_signal("CRZ_CTRL", raw, "DISABLE_TIMER_1", 0)
+  raw = _patch_signal("CRZ_CTRL", raw, "DISABLE_TIMER_2", 0)
+  raw = _patch_signal("CRZ_CTRL", raw, "RADAR_HAS_LEAD", int(lead_visible))
+  # Stock resume transitions rely on more than the coarse 0x21c templates. The
+  # live radar path preserves these fields automatically, but the synthetic path
+  # has to set them explicitly to match passive hold (distance 4), active
+  # stop-go / resume (distance 3 + ACC_GAS_MAYBE2), and follow (distance 2).
+  if crz_hold_passive or crz_hold_latched:
+    raw = _patch_signal("CRZ_CTRL", raw, "RADAR_LEAD_RELATIVE_DISTANCE", 4)
+    raw = _patch_signal("CRZ_CTRL", raw, "ACC_GAS_MAYBE2", 0)
+  elif hold_request or crz_resume_active:
+    raw = _patch_signal("CRZ_CTRL", raw, "RADAR_LEAD_RELATIVE_DISTANCE", 3)
+    raw = _patch_signal("CRZ_CTRL", raw, "ACC_GAS_MAYBE2", 1)
+  return raw
+
+
+def create_longitudinal_messages(bus: int, accel: float, counter: int, long_active: bool,
+                                 lead_visible: bool, standstill: bool, *, hold_request: bool = False,
+                                 crz_ctrl_hold_request: bool | None = None,
+                                 hold_latched: bool = False, crz_hold_latched: bool = False,
+                                 crz_hold_passive: bool = False,
+                                 crz_resume_active: bool = False,
+                                 crz_info_resume_unlatching: bool = False,
+                                 v_ego: float = 0.0) -> list[CanData]:
+  if crz_ctrl_hold_request is None:
+    crz_ctrl_hold_request = hold_request
+
+  return [
+    CanData(CRZ_INFO_ADDR, build_crz_info(accel, counter, long_active, hold_request, v_ego,
+                                          hold_latched=hold_latched,
+                                          resume_unlatching=crz_info_resume_unlatching), bus),
+    CanData(CRZ_CTRL_ADDR, build_crz_ctrl(long_active, lead_visible, crz_ctrl_hold_request, hold_latched,
+                                          crz_hold_latched=crz_hold_latched,
+                                          crz_hold_passive=crz_hold_passive,
+                                          crz_resume_active=crz_resume_active), bus),
+  ]
+
+
+def create_radar_tester_present(bus: int = RADAR_BUS) -> CanData:
+  return make_tester_present_msg(RADAR_ADDR, bus, suppress_response=True)
+
+def _uds_request(can_recv, can_send, bus: int, addr: int, request: bytes, response: bytes,
+                 *, timeout: float = 0.1) -> bool:
+  query = IsoTpParallelQuery(can_send, can_recv, bus, [(addr, None)], [request], [response])
+  return len(query.get_data(timeout)) > 0
+
+
+def enter_radar_programming_session(can_recv, can_send, bus: int = RADAR_BUS, addr: int = RADAR_ADDR,
+                                    retry: int = 5) -> bool:
+  request = bytes([uds.SERVICE_TYPE.DIAGNOSTIC_SESSION_CONTROL, uds.SESSION_TYPE.PROGRAMMING])
+  response = bytes([uds.SERVICE_TYPE.DIAGNOSTIC_SESSION_CONTROL + 0x40, uds.SESSION_TYPE.PROGRAMMING])
+
+  for attempt in range(retry):
+    try:
+      if _uds_request(can_recv, can_send, bus, addr, request, response):
+        carlog.warning(f"mazda radar programming session enabled on {hex(addr)}")
+        return True
+    except Exception:
+      carlog.exception("mazda radar programming session exception")
+    carlog.error(f"mazda radar programming session retry ({attempt + 1})")
+
+  carlog.error("mazda radar programming session failed")
+  return False
+
+
+def request_radar_default_session(can_recv, can_send, bus: int = RADAR_BUS, addr: int = RADAR_ADDR) -> bool:
+  request = bytes([uds.SERVICE_TYPE.DIAGNOSTIC_SESSION_CONTROL, uds.SESSION_TYPE.DEFAULT])
+  response = bytes([uds.SERVICE_TYPE.DIAGNOSTIC_SESSION_CONTROL + 0x40, uds.SESSION_TYPE.DEFAULT])
+
+  try:
+    return _uds_request(can_recv, can_send, bus, addr, request, response)
+  except Exception:
+    carlog.exception("mazda radar default session exception")
+    return False

--- a/opendbc/car/mazda/longitudinal.py
+++ b/opendbc/car/mazda/longitudinal.py
@@ -183,7 +183,7 @@ def build_crz_ctrl(long_active: bool, lead_visible: bool, hold_request: bool, ho
 
 
 def create_longitudinal_messages(bus: int, accel: float, counter: int, long_active: bool,
-                                 lead_visible: bool, standstill: bool, *, hold_request: bool = False,
+                                 lead_visible: bool, *, hold_request: bool = False,
                                  crz_ctrl_hold_request: bool | None = None,
                                  hold_latched: bool = False, crz_hold_latched: bool = False,
                                  crz_hold_passive: bool = False,

--- a/opendbc/dbc/mazda_2017.dbc
+++ b/opendbc/dbc/mazda_2017.dbc
@@ -561,31 +561,39 @@ BO_ 540 CRZ_CTRL: 8 XXX
  SG_ HANDS_OFF_STEERING : 48|1@0+ (1,0) [0|1] "" XXX
  SG_ HANDS_ON_STEER_WARN : 59|4@0+ (1,0) [0|255] "" XXX
  SG_ CRZ_ACTIVE : 3|1@0+ (1,0) [0|1] "" XXX
+ SG_ MSG_1 : 0|1@0+ (1,0) [0|3] "" XXX
+ SG_ MSG_1_INV : 1|1@0+ (1,0) [0|1] "" XXX
+ SG_ MSG_1_INV_COPY : 8|1@0+ (1,0) [0|7] "" XXX
+ SG_ MSG_1_COPY : 9|1@0+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_3 : 13|1@0+ (1,0) [0|3] "" XXX
+ SG_ NEW_SIGNAL_8 : 16|1@0+ (1,0) [0|1] "" XXX
  SG_ CRZ_AVAILABLE : 17|1@0+ (1,0) [0|255] "" XXX
  SG_ DISTANCE_SETTING : 20|3@0+ (1,0) [0|7] "" XXX
- SG_ MSG_1_INV : 1|1@0+ (1,0) [0|1] "" XXX
- SG_ MSG_1_COPY : 9|1@0+ (1,0) [0|1] "" XXX
- SG_ ACC_GAS_MAYBE : 23|1@0+ (1,0) [0|31] "" XXX
- SG_ ACC_ACTIVE_2 : 52|1@0+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_10 : 30|1@0+ (1,0) [0|1] "" XXX
- SG_ MSG_1 : 0|1@0+ (1,0) [0|3] "" XXX
- SG_ 5_SEC_DISABLE_TIMER : 45|3@0+ (1,0) [0|7] "" XXX
- SG_ NEW_SIGNAL_3 : 13|1@0+ (1,0) [0|3] "" XXX
- SG_ MSG_1_INV_COPY : 8|1@0+ (1,0) [0|7] "" XXX
+ SG_ NEW_SIGNAL_7 : 22|2@0+ (1,0) [0|3] "" XXX
  SG_ RADAR_HAS_LEAD : 23|1@0+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_9 : 28|15@0+ (1,0) [0|16383] "" XXX
  SG_ RADAR_LEAD_RELATIVE_DISTANCE : 31|3@0+ (1,0) [0|5] "" XXX
+ SG_ NEW_SIGNAL_5 : 42|6@0+ (1,0) [0|3] "" XXX
+ SG_ DISABLE_TIMER_1 : 43|3@1+ (1,0) [0|7] "" XXX
+ SG_ DISABLE_TIMER_2 : 48|1@0+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_6 : 49|3@1+ (1,0) [0|3] "" XXX
+ SG_ ACC_ACTIVE_2 : 52|1@0+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_4 : 63|8@0+ (1,0) [0|3] "" XXX
 
 BO_ 539 CRZ_INFO: 8 XXX
- SG_ CTR1 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ STATUS : 7|8@0+ (1,0) [0|255] "" XXX
+ SG_ STATIC_1 : 15|11@0+ (1,0) [0|2047] "" XXX
+ SG_ ACCEL_CMD : 17|13@0+ (1,-4096) [0|8191] "" XXX
+ SG_ STATIC_2 : 18|3@1+ (1,0) [0|7] "" XXX
  SG_ ACC_ACTIVE : 33|1@0+ (1,0) [0|1] "" XXX
- SG_ CHKSUM : 63|8@0+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_7 : 47|1@0+ (1,0) [0|255] "" XXX
  SG_ ACC_SET_ALLOWED : 34|1@0+ (1,0) [0|1] "" XXX
  SG_ CRZ_ENDED : 36|1@0+ (1,0) [0|255] "" XXX
- SG_ ACCEL_CMD : 17|13@0+ (1,-4096) [0|1] "" XXX
- SG_ STATIC_1 : 15|11@0+ (1,0) [0|16383] "" XXX
- SG_ STATIC_2 : 18|3@1+ (1,0) [0|3] "" XXX
- SG_ ERROR_STATUS : 7|8@0+ (1,0) [0|255] "" XXX
+ SG_ STOPPING_MAYBE : 42|1@0+ (1,0) [0|1] "" XXX
+ SG_ MYSTERY_BIT : 47|1@0+ (1,0) [0|255] "" XXX
+ SG_ CTR1 : 51|4@0+ (1,0) [0|255] "" XXX
+ SG_ STOPPING_MAYBE2 : 52|1@0+ (1,0) [0|1] "" XXX
+ SG_ RESUME_UNLATCHING_MAYBE : 54|1@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 56|8@1+ (1,0) [0|255] "" XXX
 
 BO_ 121 EPB: 8 XXX
  SG_ NEW_SIGNAL_1 : 4|4@0+ (1,0) [0|255] "" XXX

--- a/opendbc/safety/modes/mazda.h
+++ b/opendbc/safety/modes/mazda.h
@@ -115,6 +115,9 @@ static bool mazda_tx_hook(const CANPacket_t *msg) {
         .inactive_accel = 0,
       };
 
+      // Mazda's CRZ_INFO.ACCEL_CMD packing in this stack follows the DBC
+      // bit ordering used by set_value() in opendbc, which places the 13-bit
+      // raw command across data[2] low bits, all of data[3], and data[4] high bits.
       int desired_accel = ((((int)msg->data[2] & 0x3U) << 11) | (((int)msg->data[3]) << 3) | (((int)msg->data[4]) >> 5)) - 4096;
       if (longitudinal_accel_checks(desired_accel, MAZDA_LONG_LIMITS)) {
         tx = false;

--- a/opendbc/safety/modes/mazda.h
+++ b/opendbc/safety/modes/mazda.h
@@ -5,8 +5,10 @@
 // CAN msgs we care about
 #define MAZDA_LKAS          0x243U
 #define MAZDA_LKAS_HUD      0x440U
+#define MAZDA_CRZ_INFO      0x21bU
 #define MAZDA_CRZ_CTRL      0x21cU
 #define MAZDA_CRZ_BTNS      0x09dU
+#define MAZDA_RADAR_UDS     0x764U
 #define MAZDA_STEER_TORQUE  0x240U
 #define MAZDA_ENGINE_DATA   0x202U
 #define MAZDA_PEDALS        0x165U
@@ -14,6 +16,12 @@
 // CAN bus numbers
 #define MAZDA_MAIN 0
 #define MAZDA_CAM  2
+
+enum {
+  MAZDA_PARAM_LONGITUDINAL = 1,
+};
+
+static bool mazda_longitudinal = false;
 
 // track msgs coming from OP so that we know what CAM msgs to drop and what to forward
 static void mazda_rx_hook(const CANPacket_t *msg) {
@@ -30,11 +38,20 @@ static void mazda_rx_hook(const CANPacket_t *msg) {
       update_sample(&torque_driver, torque_driver_new);
     }
 
-    // enter controls on rising edge of ACC, exit controls on ACC off
     if (msg->addr == MAZDA_CRZ_CTRL) {
-      bool cruise_engaged = msg->data[0] & 0x8U;
-      pcm_cruise_check(cruise_engaged);
-      acc_main_on = GET_BIT(msg, 17U);
+      if (!mazda_longitudinal) {
+        // enter controls on rising edge of ACC, exit controls on ACC off
+        bool cruise_engaged = msg->data[0] & 0x8U;
+        pcm_cruise_check(cruise_engaged);
+        acc_main_on = GET_BIT(msg, 17U);
+      }
+    }
+
+    if (msg->addr == MAZDA_CRZ_BTNS && mazda_longitudinal) {
+      bool cancel = GET_BIT(msg, 0U);
+      if (cancel) {
+        controls_allowed = false;
+      }
     }
 
     if (msg->addr == MAZDA_ENGINE_DATA) {
@@ -42,7 +59,24 @@ static void mazda_rx_hook(const CANPacket_t *msg) {
     }
 
     if (msg->addr == MAZDA_PEDALS) {
-      brake_pressed = (msg->data[0] & 0x10U);
+      bool brake = (msg->data[0] & 0x10U);
+      if (mazda_longitudinal) {
+        // Radar suppression removes the stock CRZ_CTRL frame, so derive Mazda's
+        // "main on" state from PEDALS instead. ACC_OFF means MRCC is armed but
+        // not actively controlling, and ACC_ACTIVE means stock ACC is engaged.
+        bool cruise_engaged = GET_BIT(msg, 3U);
+        bool acc_armed = GET_BIT(msg, 2U) || cruise_engaged;
+        acc_main_on = acc_armed;
+
+        // Only feed PEDALS into pcm_cruise_check when the ACC state is actually
+        // meaningful. Brake-only samples can arrive with both ACC bits low while
+        // the driver is holding the pedal; treating those as a stock ACC-off edge
+        // drops controls before the normal brake-edge logic runs.
+        if (acc_armed || cruise_engaged_prev || (!brake && !brake_pressed_prev)) {
+          pcm_cruise_check(cruise_engaged);
+        }
+      }
+      brake_pressed = brake;
     }
   }
 }
@@ -70,6 +104,39 @@ static bool mazda_tx_hook(const CANPacket_t *msg) {
       }
     }
 
+    if (mazda_longitudinal && (msg->addr == MAZDA_CRZ_INFO)) {
+      // Keep Panda's Mazda-long safety window aligned with the software clip in
+      // opendbc/car/mazda/longitudinal.py. If this is tighter than the sender,
+      // Panda will silently drop 0x21b frames once ACCEL_CMD crosses the
+      // safety threshold, which looks like an unexplained set-speed unlatch.
+      const LongitudinalLimits MAZDA_LONG_LIMITS = {
+        .max_accel = 2000,
+        .min_accel = -2000,
+        .inactive_accel = 0,
+      };
+
+      int desired_accel = ((((int)msg->data[2] & 0x3U) << 11) | (((int)msg->data[3]) << 3) | (((int)msg->data[4]) >> 5)) - 4096;
+      if (longitudinal_accel_checks(desired_accel, MAZDA_LONG_LIMITS)) {
+        tx = false;
+      }
+    }
+
+    if (mazda_longitudinal && (msg->addr == MAZDA_CRZ_CTRL)) {
+      bool cruise_active = GET_BIT(msg, 3U);
+      if (!controls_allowed && cruise_active) {
+        tx = false;
+      }
+    }
+
+    if (mazda_longitudinal && (msg->addr == MAZDA_RADAR_UDS)) {
+      bool tester_present = (msg->data[0] == 0x02U) && (msg->data[1] == 0x3EU) && (msg->data[2] == 0x80U);
+      bool session_control = (msg->data[0] == 0x02U) && (msg->data[1] == 0x10U) &&
+                             ((msg->data[2] == 0x01U) || (msg->data[2] == 0x02U));
+      if (!tester_present && !session_control) {
+        tx = false;
+      }
+    }
+
     // cruise buttons check
     if (msg->addr == MAZDA_CRZ_BTNS) {
       // allow resume spamming while controls allowed, but
@@ -85,7 +152,19 @@ static bool mazda_tx_hook(const CANPacket_t *msg) {
 }
 
 static safety_config mazda_init(uint16_t param) {
-  static const CanMsg MAZDA_TX_MSGS[] = {{MAZDA_LKAS, 0, 8, .check_relay = true}, {MAZDA_CRZ_BTNS, 0, 8, .check_relay = false}, {MAZDA_LKAS_HUD, 0, 8, .check_relay = true}};
+  static const CanMsg MAZDA_TX_MSGS[] = {
+    {MAZDA_LKAS, 0, 8, .check_relay = true},
+    {MAZDA_CRZ_BTNS, 0, 8, .check_relay = false},
+    {MAZDA_LKAS_HUD, 0, 8, .check_relay = true},
+  };
+  static const CanMsg MAZDA_LONG_TX_MSGS[] = {
+    {MAZDA_LKAS, 0, 8, .check_relay = true},
+    {MAZDA_CRZ_BTNS, 0, 8, .check_relay = false},
+    {MAZDA_LKAS_HUD, 0, 8, .check_relay = true},
+    {MAZDA_CRZ_INFO, 0, 8, .check_relay = false},
+    {MAZDA_CRZ_CTRL, 0, 8, .check_relay = false},
+    {MAZDA_RADAR_UDS, 0, 8, .check_relay = false},
+  };
 
   static RxCheck mazda_rx_checks[] = {
     {.msg = {{MAZDA_CRZ_CTRL,     0, 8, 50U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},
@@ -94,9 +173,18 @@ static safety_config mazda_init(uint16_t param) {
     {.msg = {{MAZDA_ENGINE_DATA,  0, 8, 100U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},
     {.msg = {{MAZDA_PEDALS,       0, 8, 50U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},
   };
+  static RxCheck mazda_long_rx_checks[] = {
+    {.msg = {{MAZDA_CRZ_BTNS,     0, 8, 10U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},
+    {.msg = {{MAZDA_STEER_TORQUE, 0, 8, 83U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},
+    {.msg = {{MAZDA_ENGINE_DATA,  0, 8, 100U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},
+    {.msg = {{MAZDA_PEDALS,       0, 8, 50U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},
+  };
 
-  SAFETY_UNUSED(param);
-  return BUILD_SAFETY_CFG(mazda_rx_checks, MAZDA_TX_MSGS);
+  mazda_longitudinal = GET_FLAG(param, MAZDA_PARAM_LONGITUDINAL);
+  acc_main_on = false;
+
+  return mazda_longitudinal ? BUILD_SAFETY_CFG(mazda_long_rx_checks, MAZDA_LONG_TX_MSGS) :
+                              BUILD_SAFETY_CFG(mazda_rx_checks, MAZDA_TX_MSGS);
 }
 
 const safety_hooks mazda_hooks = {

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -910,6 +910,8 @@ class SafetyTest(SafetyTestBase):
               continue
             if attr.startswith('TestHyundaiCanfd') and current_test.startswith('TestHyundaiCanfd'):
               continue
+            if {attr, current_test}.issubset({'TestMazdaSafety', 'TestMazdaLongitudinalSafety'}):
+              tx = list(filter(lambda m: m not in self.TX_MSGS, tx))
             if {attr, current_test}.issubset({'TestHyundaiLongitudinalSafety', 'TestHyundaiLongitudinalSafetyCameraSCC', 'TestHyundaiSafetyFCEVLong'}):
               continue
             base_tests = {'TestHyundaiLongitudinalSafety', 'TestHyundaiLongitudinalSafetyCameraSCC', 'TestHyundaiSafetyFCEVLong',

--- a/opendbc/safety/tests/test_mazda.py
+++ b/opendbc/safety/tests/test_mazda.py
@@ -81,5 +81,20 @@ class TestMazdaSafety(common.CarSafetyTest, common.DriverTorqueSteeringSafetyTes
     self.assertTrue(self._tx(self._button_msg(resume=True)))
 
 
+class TestMazdaLongitudinalSafety(TestMazdaSafety):
+
+  TX_MSGS = [[0x243, 0], [0x09d, 0], [0x440, 0], [0x21b, 0], [0x21c, 0], [0x764, 0]]
+
+  def setUp(self):
+    self.packer = CANPackerSafety("mazda_2017")
+    self.safety = libsafety_py.libsafety
+    self.safety.set_safety_hooks(CarParams.SafetyModel.mazda, 1)
+    self.safety.init_tests()
+
+  def _pcm_status_msg(self, enable):
+    values = {"ACC_ACTIVE": enable, "BRAKE_ON": 0}
+    return self.packer.make_can_msg_safety("PEDALS", 0, values)
+
+
 if __name__ == "__main__":
   unittest.main()

--- a/opendbc/safety/tests/test_mazda.py
+++ b/opendbc/safety/tests/test_mazda.py
@@ -81,9 +81,12 @@ class TestMazdaSafety(common.CarSafetyTest, common.DriverTorqueSteeringSafetyTes
     self.assertTrue(self._tx(self._button_msg(resume=True)))
 
 
-class TestMazdaLongitudinalSafety(TestMazdaSafety):
+class TestMazdaLongitudinalSafety(TestMazdaSafety, common.LongitudinalAccelSafetyTest):
 
   TX_MSGS = [[0x243, 0], [0x09d, 0], [0x440, 0], [0x21b, 0], [0x21c, 0], [0x764, 0]]
+  MAX_ACCEL = 2000.0
+  MIN_ACCEL = -2000.0
+  INACTIVE_ACCEL = 0.0
 
   def setUp(self):
     self.packer = CANPackerSafety("mazda_2017")
@@ -94,6 +97,25 @@ class TestMazdaLongitudinalSafety(TestMazdaSafety):
   def _pcm_status_msg(self, enable):
     values = {"ACC_ACTIVE": enable, "BRAKE_ON": 0}
     return self.packer.make_can_msg_safety("PEDALS", 0, values)
+
+  def _accel_msg(self, accel: float):
+    values = {"ACCEL_CMD": accel}
+    return self.packer.make_can_msg_safety("CRZ_INFO", 0, values)
+
+  def test_accel_actuation_limits(self):
+    # CRZ_INFO.ACCEL_CMD is a raw integer command in Mazda's DBC, so use
+    # integer-domain boundaries to avoid float rounding artifacts in packing.
+    limits = ((self.MIN_ACCEL, self.MAX_ACCEL, common.ALTERNATIVE_EXPERIENCE.DEFAULT),
+              (self.MIN_ACCEL, self.MAX_ACCEL, common.ALTERNATIVE_EXPERIENCE.RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX))
+
+    for min_accel, max_accel, alternative_experience in limits:
+      for accel in range(int(min_accel) - 1, int(max_accel) + 2):
+        for controls_allowed in [True, False]:
+          self.safety.set_controls_allowed(controls_allowed)
+          self.safety.set_alternative_experience(alternative_experience)
+          should_tx = controls_allowed and min_accel <= accel <= max_accel
+          should_tx = should_tx or accel == self.INACTIVE_ACCEL
+          self.assertEqual(should_tx, self._tx(self._accel_msg(float(accel))))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request adds support for full alpha longitudinal on the Mazda CX-5. The method I used to achieve this involved poisoning the stock radar unit by placing it in "programming" session and sending "tester-present" messages to hold it in that state, and then essentially emulating that radar unit enough to prevent a full malfunction that would disable the ability to trigger MRCC. It is important to note that doing this necessarily disables AEB braking, and as of the current state of these changes, triggers a few malfunctions to show on the dash. None of these impair car function, and across many test drives, alpha longitudinal has worked without triggering errors or exhibiting any unusual unsafe behavior.

This is my first contribution to this project, and, clearly, it's a large one in size, so I welcome any and all critiques or suggestions that need to be addressed before merging all this.

The following is Copilot's summary of my changes (reviewed by me):

**Longitudinal Control Integration and Logic:**

* Added support for openpilot-managed longitudinal control, including logic for synthetic stop-and-go/HOLD, resume handling, and synthetic ACC message generation in `carcontroller.py`. This includes new state variables and careful management of transitions between stopping, holding, and starting, as well as handling both physical and virtual resume requests. [[1]](diffhunk://#diff-81fe04426a7c807332ac7cb3526d66b5275ded0729578fea78c1441181a58fe0L2-R21) [[2]](diffhunk://#diff-81fe04426a7c807332ac7cb3526d66b5275ded0729578fea78c1441181a58fe0R31-R39) [[3]](diffhunk://#diff-81fe04426a7c807332ac7cb3526d66b5275ded0729578fea78c1441181a58fe0R52-R53) [[4]](diffhunk://#diff-81fe04426a7c807332ac7cb3526d66b5275ded0729578fea78c1441181a58fe0R70-R208)

**Cruise State and Button Event Handling:**

* Refined parsing and reporting of cruise control button events (including main, cancel, accel, decel, and distance) to support both stock and openpilot longitudinal control. Updated cruise state detection to use radar signals when in openpilot longitudinal mode, ensuring accurate availability and engagement status. [[1]](diffhunk://#diff-be7075277f54e02ec59e95a15075be5a68095ba6175d64acbeee648258198128R24-R33) [[2]](diffhunk://#diff-be7075277f54e02ec59e95a15075be5a68095ba6175d64acbeee648258198128L83-R134) [[3]](diffhunk://#diff-be7075277f54e02ec59e95a15075be5a68095ba6175d64acbeee648258198128L115-L128)

**Car Interface and Parameters:**

* Updated `interface.py` to enable openpilot longitudinal control only for supported models (CX-5 2022), set appropriate car parameters (starting state, accel values, actuator delay, PID tuning), and configure the safety model accordingly. [[1]](diffhunk://#diff-e9f4ba4989d4b5ef60ca88571f8c260acba8aa2f26fbc5e6de2a0758110bbadeR7-R11) [[2]](diffhunk://#diff-e9f4ba4989d4b5ef60ca88571f8c260acba8aa2f26fbc5e6de2a0758110bbadeL17-R27) [[3]](diffhunk://#diff-e9f4ba4989d4b5ef60ca88571f8c260acba8aa2f26fbc5e6de2a0758110bbadeR40-R50)

**Radar Session Management:**

* Added initialization and deinitialization hooks to enter/exit radar programming session when openpilot longitudinal control is enabled, ensuring proper radar behavior during take-over and handoff.

These changes collectively enable a robust openpilot longitudinal control experience on supported Mazda vehicles, with careful handling of state transitions, user inputs, and compatibility with stock systems.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID: 21d103861daeed11
* Route: https://connect.comma.ai/21d103861daeed11/00000015--fba69e0004
