### PR TITLE
Rivian: suppress ACM hold-the-wheel warning during MADS-only lateral

### DIFF
--- a/opendbc/car/rivian/carcontroller.py
+++ b/opendbc/car/rivian/carcontroller.py
@@ -36,7 +36,7 @@ class CarController(CarControllerBase, MadsCarController):
     can_sends.append(create_lka_steering(self.packer, self.frame, CS.acm_lka_hba_cmd, apply_torque, CC.enabled, CC.latActive, self.mads))
 
     if self.frame % 5 == 0 and not (self.CP.flags & RivianFlags.GEN2):
-      can_sends.append(create_wheel_touch(self.packer, CS.sccm_wheel_touch, CC.enabled))
+      can_sends.append(create_wheel_touch(self.packer, CS.sccm_wheel_touch, self.mads.lat_active))
 
     # Longitudinal control
     if self.CP.openpilotLongitudinalControl:


### PR DESCRIPTION
The wheel-touch override that fakes HandsOn=1 to suppress the ACM's "hold the wheel" warning was gated on CC.enabled, which is False when the user runs MADS lateral without ACC. In that mode the ACM sees the real (intermittent) SCCM_WheelTouch signal and escalates to the loud red-message warning even though openpilot is steering.

Gate on self.mads.lat_active instead so the override fires whenever openpilot is doing lateral control, including MADS-only mode.