### PR TITLE
hyundai: add Tucson Hybrid GEN (Korean) 2026 firmware fingerprint

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1182,8 +1182,9 @@ FW_VERSIONS = {
   },
   CAR.HYUNDAI_TUCSON_HEV_2025: {
     (Ecu.fwdCamera, 0x7c4, None): [
-      b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N7030 C55',
       b'\xf1\x00NX4 FR_CMR AT EUR LHD 1.00 1.00 99211-N7030 C55',
+      b'\xf1\x00NX4 FR_CMR AT GEN LHD 1.00 1.00 99211-N7030 C55',
+      b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N7030 C55',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00NX4__               1.00 1.02 99110N7000          ',


### PR DESCRIPTION
Add missing fwdCamera GEN-region firmware for HYUNDAI_TUCSON_HEV_2025. Part number 99211-N7030 C55 already existed for USA/EUR variants; this covers the generic/Korean market variant (VIN model year T = 2026). Radar firmware 99110N7000 was already in the database.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID: cea5d2d878f58ed3
* Route: cea5d2d878f58ed3/00000001--b4454fd45f/1
