### PR TITLE
Subaru: Automatic Vehicle Hold (AVH) for SUBARU_IMPREZA_2020

### DIFF
--- a/opendbc/car/subaru/carcontroller.py
+++ b/opendbc/car/subaru/carcontroller.py
@@ -2,10 +2,11 @@ import numpy as np
 from opendbc.can import CANPacker
 from opendbc.car import Bus, make_tester_present_msg
 from opendbc.car.lateral import apply_driver_steer_torque_limits, common_fault_avoidance
-from opendbc.car.interfaces import CarControllerBase
+from opendbc.car.interfaces import CarControllerBase, GearShifter
 from opendbc.car.subaru import subarucan
 from opendbc.car.subaru.values import DBC, GLOBAL_ES_ADDR, CanBus, CarControllerParams, SubaruFlags
 
+from opendbc.sunnypilot.car.subaru import subarucan_ext
 from opendbc.sunnypilot.car.subaru.stop_and_go import SnGCarController
 
 # FIXME: These limits aren't exact. The real limit is more than likely over a larger time period and
@@ -22,9 +23,50 @@ class CarController(CarControllerBase, SnGCarController):
 
     self.cruise_button_prev = 0
     self.steer_rate_counter = 0
+    self._brake_hold_primed = False
+    self._brake_hold_active = False
 
     self.p = CarControllerParams(CP)
     self.packer = CANPacker(DBC[CP.carFingerprint][Bus.pt])
+
+  def _update_brake_hold_state(self, CC_SP, CS):
+    """Velocity-primed brake-hold latch: primes during deceleration before mads.active
+    drops, holds at standstill, releases on gas / mads-off / speed. Pure w.r.t.
+    long-control flags — the caller arbitrates whether to send the ES_Brake message.
+    """
+    if not (self.CP.flags & SubaruFlags.BRAKE_HOLD) or CS.es_brake_msg is None:
+      return None, False
+
+    # Velocity-primed latch: capture hold intent during deceleration before mads.active
+    # drops at ~0.18 m/s.
+    if CC_SP.mads.enabled and CS.out.vEgoRaw < 1.5 and CS.out.brakePressed and not CS.out.cruiseState.enabled:
+      if CS.out.gearShifter not in (GearShifter.park, GearShifter.reverse):
+        self._brake_hold_primed = True
+
+    if self.frame % 5 != 0:
+      if CS.out.cruiseState.enabled and CS.es_brake_msg["AEB_Status"] == 0:
+        self._brake_hold_active = False
+      return None, self._brake_hold_active
+
+    holding = (self._brake_hold_primed
+               and CS.out.standstill
+               and not CS.out.gasPressed
+               and not CS.out.cruiseState.enabled
+               and CS.out.gearShifter not in (GearShifter.park, GearShifter.reverse))
+
+    if CS.out.gasPressed or not CC_SP.mads.enabled or CS.out.vEgoRaw > 0.5 or CS.out.cruiseState.enabled:
+      self._brake_hold_primed = False
+
+    aeb_active = CS.es_brake_msg["AEB_Status"] != 0
+    if aeb_active:
+      brake_value = CS.es_brake_msg["Brake_Pressure"]
+    elif holding:
+      brake_value = CarControllerParams.BRAKE_HOLD_PRESSURE
+    else:
+      brake_value = None
+
+    self._brake_hold_active = aeb_active or holding
+    return brake_value, self._brake_hold_active
 
   def update(self, CC, CC_SP, CS, now_nanos):
     actuators = CC.actuators
@@ -108,13 +150,21 @@ class CarController(CarControllerBase, SnGCarController):
         if self.CP.flags & SubaruFlags.SEND_INFOTAINMENT:
           can_sends.append(subarucan.create_es_infotainment(self.packer, self.frame // 10, CS.es_infotainment_msg, hud_control.visualAlert))
 
+      brake_hold_value, brake_hold_active = self._update_brake_hold_state(CC_SP, CS)
+      avh_owns_es_brake = brake_hold_value is not None and not CC.longActive
+
       if self.CP.openpilotLongitudinalControl:
         if self.frame % 5 == 0:
           can_sends.append(subarucan.create_es_status(self.packer, self.frame // 5, CS.es_status_msg,
                                                       self.CP.openpilotLongitudinalControl, CC.longActive, cruise_rpm))
 
-          can_sends.append(subarucan.create_es_brake(self.packer, self.frame // 5, CS.es_brake_msg,
-                                                     self.CP.openpilotLongitudinalControl, CC.longActive, cruise_brake))
+          # ES_Brake arbitration: AVH wins when op long is not actively braking.
+          if avh_owns_es_brake:
+            can_sends.append(subarucan.create_es_brake_hold(self.packer, self.frame // 5, CS.es_brake_msg,
+                                                            self.CP.openpilotLongitudinalControl, brake_hold_value))
+          else:
+            can_sends.append(subarucan.create_es_brake(self.packer, self.frame // 5, CS.es_brake_msg,
+                                                       self.CP.openpilotLongitudinalControl, CC.longActive, cruise_brake))
 
           can_sends.append(subarucan.create_es_distance(self.packer, self.frame // 5, CS.es_distance_msg, 0, pcm_cancel_cmd,
                                                         self.CP.openpilotLongitudinalControl, cruise_brake > 0, cruise_throttle))
@@ -123,6 +173,17 @@ class CarController(CarControllerBase, SnGCarController):
           if not (self.CP.flags & SubaruFlags.HYBRID):
             bus = CanBus.alt if self.CP.flags & SubaruFlags.GLOBAL_GEN2 else CanBus.main
             can_sends.append(subarucan.create_es_distance(self.packer, CS.es_distance_msg["COUNTER"] + 1, CS.es_distance_msg, bus, pcm_cancel_cmd))
+
+        if avh_owns_es_brake and self.frame % 5 == 0:
+          can_sends.append(subarucan.create_es_brake_hold(
+            self.packer, self.frame // 5, CS.es_brake_msg, self.CP.openpilotLongitudinalControl, brake_hold_value
+          ))
+
+      # Gate the mask on `not CC.longActive` to hand it off to op long when it's
+      # braking (brake_hold_active may still be True since the helper is flag-pure).
+      if (self.CP.flags & SubaruFlags.BRAKE_HOLD and self.frame % 2 == 0
+          and CS.brake_status_msg is not None and brake_hold_active and not CC.longActive):
+        can_sends.append(subarucan_ext.create_brake_status_hold(self.packer, CS.brake_status_msg))
 
       if self.CP.flags & SubaruFlags.DISABLE_EYESIGHT:
         # Tester present (keeps eyesight disabled)

--- a/opendbc/car/subaru/carstate.py
+++ b/opendbc/car/subaru/carstate.py
@@ -19,6 +19,8 @@ class CarState(CarStateBase, MadsCarState, SnGCarState):
     self.shifter_values = can_define.dv["Transmission"]["Gear"]
 
     self.angle_rate_calulator = CanSignalRateCalculator(50)
+    self.es_brake_msg = None  # populated on first update(); guards carcontroller startup window
+    self.brake_status_msg = None
 
   def update(self, can_parsers) -> tuple[structs.CarState, structs.CarStateSP]:
     cp = can_parsers[Bus.pt]
@@ -34,6 +36,7 @@ class CarState(CarStateBase, MadsCarState, SnGCarState):
     else:
       cp_brakes = cp_alt if self.CP.flags & SubaruFlags.GLOBAL_GEN2 else cp
       ret.brakePressed = cp_brakes.vl["Brake_Status"]["Brake"] == 1
+      self.brake_status_msg = copy.copy(cp_brakes.vl["Brake_Status"])
 
     cp_es_distance = cp_alt if self.CP.flags & (SubaruFlags.GLOBAL_GEN2 | SubaruFlags.HYBRID) else cp_cam
     if not (self.CP.flags & SubaruFlags.HYBRID):

--- a/opendbc/car/subaru/subarucan.py
+++ b/opendbc/car/subaru/subarucan.py
@@ -208,6 +208,35 @@ def create_es_brake(packer, frame, es_brake_msg, long_enabled, long_active, brak
   return packer.make_can_msg("ES_Brake", CanBus.main, values)
 
 
+def create_es_brake_hold(packer, frame, es_brake_msg, long_enabled, brake_value):
+  values = {s: es_brake_msg[s] for s in [
+    "CHECKSUM",
+    "Signal1",
+    "Brake_Pressure",
+    "AEB_Status",
+    "Cruise_Brake_Lights",
+    "Cruise_Brake_Fault",
+    "Cruise_Brake_Active",
+    "Cruise_Activated",
+    "Signal3",
+  ]}
+  values["COUNTER"] = frame % 0x10
+
+  # Override the brake-relevant fields; all others pass through from Eyesight. Cruise_Activated
+  # is forwarded verbatim — forcing it to 1 during manual driving risks Eyesight fault detection.
+  values["Brake_Pressure"] = brake_value
+  values["Cruise_Brake_Active"] = brake_value > 0
+  values["Cruise_Brake_Lights"] = brake_value >= 70  # mirrors create_es_brake threshold
+
+  # When alpha-long ACC engages, Eyesight latches Cruise_Brake_Fault for the rest of the drive
+  # and ignores any ES_Brake pressure carrying it; clear it only on the long path (mirrors
+  # create_es_brake). On stock Eyesight it can't be that latch, so forward it verbatim.
+  if long_enabled:
+    values["Cruise_Brake_Fault"] = 0
+
+  return packer.make_can_msg("ES_Brake", CanBus.main, values)
+
+
 def create_es_status(packer, frame, es_status_msg, long_enabled, long_active, cruise_rpm):
   values = {s: es_status_msg[s] for s in [
     "CHECKSUM",

--- a/opendbc/car/subaru/tests/test_subarucan_brake_hold.py
+++ b/opendbc/car/subaru/tests/test_subarucan_brake_hold.py
@@ -1,0 +1,146 @@
+import unittest
+from unittest.mock import MagicMock
+from opendbc.can import CANPacker
+from opendbc.car import Bus
+from opendbc.car.subaru.values import DBC, CAR, CanBus
+from opendbc.car.subaru import subarucan
+from opendbc.sunnypilot.car.subaru import subarucan_ext
+
+
+def make_packer():
+  packer = MagicMock()
+  packer.make_can_msg.return_value = ("ES_Brake", b'\x00' * 8, 0)
+  return packer
+
+
+def make_es_brake_msg(**overrides):
+  base = {
+    "CHECKSUM": 0,
+    "Signal1": 0,
+    "Brake_Pressure": 0,
+    "AEB_Status": 0,
+    "Cruise_Brake_Lights": 0,
+    "Cruise_Brake_Fault": 0,
+    "Cruise_Brake_Active": 0,
+    "Cruise_Activated": 0,
+    "Signal3": 0,
+  }
+  base.update(overrides)
+  return base
+
+
+def get_values(packer):
+  _, _, values = packer.make_can_msg.call_args[0]
+  return values
+
+
+def make_brake_status_msg(**overrides):
+  base = {"CHECKSUM": 0, "COUNTER": 0, "Signal1": 0, "ES_Brake": 0, "Signal2": 0, "Brake": 0, "Signal3": 0}
+  base.update(overrides)
+  return base
+
+
+class TestSubarucanBrakeHold(unittest.TestCase):
+  # --- Brake_Pressure / Cruise_Brake_Active / Cruise_Brake_Lights ---
+
+  def test_brake_field_packing(self):
+    for brake_value, active, lights in [
+      (0, False, False),
+      (50, True, False),   # active >0, below 70-unit lights threshold
+      (70, True, True),    # lights threshold is inclusive
+      (100, True, True),
+      (600, True, True),
+    ]:
+      with self.subTest(brake_value=brake_value):
+        packer = make_packer()
+        subarucan.create_es_brake_hold(packer, frame=0, es_brake_msg=make_es_brake_msg(), long_enabled=True, brake_value=brake_value)
+        v = get_values(packer)
+        self.assertEqual(v["Brake_Pressure"], brake_value)
+        self.assertEqual(bool(v["Cruise_Brake_Active"]), active)
+        self.assertEqual(bool(v["Cruise_Brake_Lights"]), lights)
+
+  def test_stock_path_packs_brake_fields(self):
+    # long_enabled=False still derives Active/Lights from brake_value; only fault handling differs
+    packer = make_packer()
+    subarucan.create_es_brake_hold(packer, frame=0, es_brake_msg=make_es_brake_msg(), long_enabled=False, brake_value=100)
+    v = get_values(packer)
+    self.assertEqual(v["Brake_Pressure"], 100)
+    self.assertTrue(v["Cruise_Brake_Active"])
+    self.assertTrue(v["Cruise_Brake_Lights"])
+
+  # --- Cruise_Brake_Fault: cleared on op-long, forwarded on stock ---
+
+  def test_cruise_brake_fault_cleared_when_long_enabled(self):
+    # Eyesight latches Cruise_Brake_Fault=1 after op-long ACC engages; forwarding it poisoned the
+    # AVH hold (car rolled), so op-long forces it to 0. Route dde08cad3a74cd94/00000014--7d3ff4c569.
+    packer = make_packer()
+    subarucan.create_es_brake_hold(packer, frame=0, es_brake_msg=make_es_brake_msg(Cruise_Brake_Fault=1), long_enabled=True, brake_value=100)
+    self.assertEqual(get_values(packer)["Cruise_Brake_Fault"], 0)
+
+  def test_cruise_brake_fault_forwarded_on_stock(self):
+    # stock Eyesight ACC: the fault is genuinely Eyesight's, forward verbatim
+    packer = make_packer()
+    subarucan.create_es_brake_hold(packer, frame=0, es_brake_msg=make_es_brake_msg(Cruise_Brake_Fault=1), long_enabled=False, brake_value=100)
+    self.assertEqual(get_values(packer)["Cruise_Brake_Fault"], 1)
+
+  def test_hold_pressure_with_eyesight_fault_latched(self):
+    # regression: 600-unit hold must still go out with fault cleared when Eyesight has latched the fault
+    packer = make_packer()
+    subarucan.create_es_brake_hold(packer, frame=0, es_brake_msg=make_es_brake_msg(Cruise_Brake_Fault=1), long_enabled=True, brake_value=600)
+    v = get_values(packer)
+    self.assertEqual(v["Brake_Pressure"], 600)
+    self.assertTrue(v["Cruise_Brake_Active"])
+    self.assertEqual(v["Cruise_Brake_Fault"], 0)
+
+  # --- Passthrough fields ---
+
+  def test_cruise_activated_passthrough(self):
+    # forwarded verbatim — NOT overridden, unlike create_es_brake
+    packer = make_packer()
+    subarucan.create_es_brake_hold(packer, frame=0, es_brake_msg=make_es_brake_msg(Cruise_Activated=1), long_enabled=True, brake_value=100)
+    self.assertEqual(get_values(packer)["Cruise_Activated"], 1)
+
+  def test_signal_passthrough(self):
+    for signal, value in [("AEB_Status", 8), ("Signal1", 5), ("Signal3", 3)]:
+      with self.subTest(signal=signal):
+        packer = make_packer()
+        subarucan.create_es_brake_hold(packer, frame=0, es_brake_msg=make_es_brake_msg(**{signal: value}), long_enabled=True, brake_value=0)
+        self.assertEqual(get_values(packer)[signal], value)
+
+  # --- COUNTER ---
+
+  def test_counter(self):
+    for frame, counter in [(0, 0), (15, 15), (16, 0)]:  # 16 % 16 == 0 wraps
+      with self.subTest(frame=frame):
+        packer = make_packer()
+        subarucan.create_es_brake_hold(packer, frame=frame, es_brake_msg=make_es_brake_msg(), long_enabled=True, brake_value=0)
+        self.assertEqual(get_values(packer)["COUNTER"], counter)
+
+  # --- Real CANPacker smoke test (catches DBC signal-name drift; also covers msg name + bus) ---
+
+  def test_real_packer_accepts_signals(self):
+    packer = CANPacker(DBC[CAR.SUBARU_IMPREZA_2020.value][Bus.pt])
+    addr, dat, bus = subarucan.create_es_brake_hold(packer, frame=0, es_brake_msg=make_es_brake_msg(),
+                                                    long_enabled=True, brake_value=600)
+    self.assertEqual(addr, 0x220)
+    self.assertEqual(bus, CanBus.main)
+    self.assertEqual(len(dat), 8)
+
+  # --- Brake_Status ES_Brake bit must stay at byte 7 bit 2 (panda reads `(data[7] >> 2) & 1`) ---
+
+  def test_brake_status_es_brake_bit_offset_matches_safety(self):
+    # Pin the DBC ES_Brake location to the hardcoded panda offset; a DBC move would silently
+    # desync subaru_tx_hook's Brake_Status check from create_brake_status_hold's packing.
+    packer = CANPacker(DBC[CAR.SUBARU_IMPREZA_2020.value][Bus.pt])
+    _, dat_set, _ = packer.make_can_msg("Brake_Status", CanBus.camera, make_brake_status_msg(ES_Brake=1))
+    self.assertEqual(dat_set[7], 0x04)  # only ES_Brake set -> byte 7 bit 2
+
+    # the hold mask clears that exact bit while forwarding Brake (bit 6)
+    _, dat_hold, bus = subarucan_ext.create_brake_status_hold(packer, make_brake_status_msg(ES_Brake=1, Brake=1))
+    self.assertEqual((dat_hold[7] >> 2) & 1, 0)
+    self.assertEqual((dat_hold[7] >> 6) & 1, 1)
+    self.assertEqual(bus, CanBus.camera)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/opendbc/car/subaru/values.py
+++ b/opendbc/car/subaru/values.py
@@ -51,6 +51,8 @@ class CarControllerParams:
   BRAKE_LOOKUP_BP = [-3.5, 0]
   BRAKE_LOOKUP_V = [BRAKE_MAX, BRAKE_MIN]
 
+  BRAKE_HOLD_PRESSURE = 600  # max pressure; ensures hold on slopes
+
 
 class SubaruSafetyFlags(IntFlag):
   GEN2 = 1
@@ -72,6 +74,7 @@ class SubaruFlags(IntFlag):
   PREGLOBAL = 16
   HYBRID = 32
   LKAS_ANGLE = 64
+  BRAKE_HOLD = 128  # ES_Brake intercept brake hold feature
 
 
 GLOBAL_ES_ADDR = 0x787

--- a/opendbc/safety/modes/subaru.h
+++ b/opendbc/safety/modes/subaru.h
@@ -79,6 +79,15 @@
 
 static bool subaru_gen2 = false;
 static bool subaru_longitudinal = false;
+// Settling window: covers Python lag (~10ms) so hold injections stay valid for a few frames
+// after vehicle_moving transitions.
+static int brake_intercept_release_countdown = 0;
+#define BRAKE_INTERCEPT_RELEASE_FRAMES 3
+
+// Nonzero while a hold is being asserted; fwd_hook uses it to block the relays only during a
+// hold, so Eyesight's native ACC works when idle.
+static int subaru_brake_hold_active_countdown = 0;
+#define SUBARU_BRAKE_HOLD_ACTIVE_FRAMES 4
 
 static uint32_t subaru_get_checksum(const CANPacket_t *msg) {
   return (uint8_t)msg->data[0];
@@ -131,6 +140,22 @@ static void subaru_rx_hook(const CANPacket_t *msg) {
     vehicle_moving = (fr > 0U) || (rr > 0U) || (rl > 0U) || (fl > 0U);
 
     UPDATE_VEHICLE_SPEED((fr + rr + rl + fl) / 4.0 * 0.057 * KPH_TO_MS);
+
+    // Age the settling/hold countdowns off Wheel_Speeds RX (50Hz, 1 frame = 20ms).
+    if (subaru_brake_intercept) {
+      if (vehicle_moving) {
+        if (brake_intercept_release_countdown < BRAKE_INTERCEPT_RELEASE_FRAMES) {
+          brake_intercept_release_countdown++;
+        }
+      } else {
+        brake_intercept_release_countdown = 0;
+      }
+
+      // When this hits 0, fwd_hook restores the relays so Eyesight's ACC can operate.
+      if (subaru_brake_hold_active_countdown > 0) {
+        subaru_brake_hold_active_countdown--;
+      }
+    }
   }
 
   if ((msg->addr == MSG_SUBARU_Brake_Status) && (msg->bus == alt_main_bus)) {
@@ -173,7 +198,30 @@ static bool subaru_tx_hook(const CANPacket_t *msg) {
   // check es_brake brake_pressure limits
   if (msg->addr == MSG_SUBARU_ES_Brake) {
     int es_brake_pressure = GET_BYTES(msg, 2, 2);
-    violation |= longitudinal_brake_checks(es_brake_pressure, SUBARU_LONG_LIMITS);
+
+    if (subaru_brake_intercept) {
+      // ES_Brake is valid if EITHER the AVH set OR the standard longitudinal set permits it.
+      bool standstill_or_settling = !vehicle_moving || (brake_intercept_release_countdown < BRAKE_INTERCEPT_RELEASE_FRAMES);
+
+      bool avh_pressure_invalid = (es_brake_pressure > SUBARU_LONG_LIMITS.max_brake);
+      // Gas intentionally NOT gated here: the same frame carries Eyesight's AEB echo (which must
+      // never be gas-gated) and braking is fail-safe (bounded by authority + pressure + standstill).
+      bool avh_no_authority     = (!controls_allowed && !controls_allowed_lateral) && (es_brake_pressure != 0);
+      bool avh_not_standstill   = !standstill_or_settling && (es_brake_pressure != 0);
+      bool avh_valid = !(avh_pressure_invalid || avh_no_authority || avh_not_standstill);
+
+      bool long_valid = subaru_longitudinal && !longitudinal_brake_checks(es_brake_pressure, SUBARU_LONG_LIMITS);
+
+      violation |= !(avh_valid || long_valid);
+
+      // Bump only on the AVH hold path. Bumping for op-long braking (long_valid) would starve
+      // Eyesight's Brake_Status relay and briefly block Eyesight AEB when op-long disengages.
+      if (!violation && avh_valid && (es_brake_pressure > 0)) {
+        subaru_brake_hold_active_countdown = SUBARU_BRAKE_HOLD_ACTIVE_FRAMES;
+      }
+    } else {
+      violation |= longitudinal_brake_checks(es_brake_pressure, SUBARU_LONG_LIMITS);
+    }
   }
 
   // check es_distance cruise_throttle limits
@@ -195,6 +243,19 @@ static bool subaru_tx_hook(const CANPacket_t *msg) {
   if (msg->addr == MSG_SUBARU_ES_Status) {
     int transmission_rpm = (GET_BYTES(msg, 2, 2) & 0x1FFFU);
     violation |= longitudinal_transmission_rpm_checks(transmission_rpm, SUBARU_LONG_LIMITS);
+  }
+
+  // openpilot sends a modified 0x13C (ES_Brake bit cleared) to the camera bus so Eyesight
+  // doesn't see the braking module's ES_Brake feedback during a hold.
+  if (msg->addr == MSG_SUBARU_Brake_Status) {
+    bool es_brake_bit = (msg->data[7] >> 2) & 1U;
+    violation |= !subaru_brake_intercept;  // only allowed in brake_intercept mode
+    violation |= es_brake_bit;             // ES_Brake bit must be cleared
+
+    // TXing the mask means we're asserting a hold; bump so fwd_hook blocks the real Brake_Status.
+    if (!violation) {
+      subaru_brake_hold_active_countdown = SUBARU_BRAKE_HOLD_ACTIVE_FRAMES;
+    }
   }
 
   if (msg->addr == MSG_SUBARU_ES_UDS_Request) {
@@ -241,6 +302,46 @@ static safety_config subaru_init(uint16_t param) {
     SUBARU_STOP_AND_GO_TX_MSGS
   };
 
+  // Brake-intercept only (no SnG). ES_Brake/Brake_Status keep check_relay=true for malfunction
+  // detection but use disable_static_blocking=true so the relay block lives in subaru_fwd_hook
+  // (only during a hold), letting Eyesight's native ACC drive them when idle.
+  // No Brake_Pedal: openpilot never sends it here, so leave the relay free to forward the car's
+  // real Brake_Pedal to Eyesight. Listing it statically blocked that relay → Eyesight RX timeout
+  // → fault whenever AVH was on and SnG off (hardware-confirmed harmful, removed 2026-05-22).
+  static const CanMsg subaru_brake_intercept_tx_msgs[] = {
+    SUBARU_BASE_TX_MSGS(SUBARU_MAIN_BUS, MSG_SUBARU_ES_LKAS)
+    SUBARU_COMMON_TX_MSGS(SUBARU_MAIN_BUS)
+    {MSG_SUBARU_ES_Brake,     SUBARU_MAIN_BUS, 8, .check_relay = true, .disable_static_blocking = true},
+    {MSG_SUBARU_Brake_Status, SUBARU_CAM_BUS,  8, .check_relay = true, .disable_static_blocking = true},
+  };
+
+  // SnG + brake-intercept: full SnG msgs plus explicitly-listed ES_Brake/Brake_Status.
+  static const CanMsg subaru_sng_brake_intercept_tx_msgs[] = {
+    SUBARU_BASE_TX_MSGS(SUBARU_MAIN_BUS, MSG_SUBARU_ES_LKAS)
+    SUBARU_COMMON_TX_MSGS(SUBARU_MAIN_BUS)
+    SUBARU_STOP_AND_GO_TX_MSGS
+    {MSG_SUBARU_ES_Brake,     SUBARU_MAIN_BUS, 8, .check_relay = true, .disable_static_blocking = true},
+    {MSG_SUBARU_Brake_Status, SUBARU_CAM_BUS,  8, .check_relay = true, .disable_static_blocking = true},
+  };
+
+  // alpha long + brake_intercept (no SnG). ES_Brake comes from SUBARU_COMMON_LONG_TX_MSGS with
+  // static blocking on — op long owns the cam→main relay. Brake_Status uses conditional fwd_hook
+  // blocking. No Brake_Pedal: openpilot never sends it here, so the relay forwards the car's real
+  // Brake_Pedal to Eyesight (same leftover removed from subaru_brake_intercept_tx_msgs above).
+  static const CanMsg subaru_long_brake_intercept_tx_msgs[] = {
+    SUBARU_BASE_TX_MSGS(SUBARU_MAIN_BUS, MSG_SUBARU_ES_LKAS)
+    SUBARU_COMMON_LONG_TX_MSGS(SUBARU_MAIN_BUS)
+    {MSG_SUBARU_Brake_Status, SUBARU_CAM_BUS, 8, .check_relay = true, .disable_static_blocking = true},
+  };
+
+  // alpha long + SnG + brake_intercept: same as above plus Throttle (cam).
+  static const CanMsg subaru_long_sng_brake_intercept_tx_msgs[] = {
+    SUBARU_BASE_TX_MSGS(SUBARU_MAIN_BUS, MSG_SUBARU_ES_LKAS)
+    SUBARU_COMMON_LONG_TX_MSGS(SUBARU_MAIN_BUS)
+    SUBARU_STOP_AND_GO_TX_MSGS
+    {MSG_SUBARU_Brake_Status, SUBARU_CAM_BUS, 8, .check_relay = true, .disable_static_blocking = true},
+  };
+
   static RxCheck subaru_rx_checks[] = {
     SUBARU_COMMON_RX_CHECKS(SUBARU_MAIN_BUS)
   };
@@ -252,6 +353,7 @@ static safety_config subaru_init(uint16_t param) {
   const uint16_t SUBARU_PARAM_GEN2 = 1;
 
   subaru_gen2 = GET_FLAG(param, SUBARU_PARAM_GEN2);
+  subaru_longitudinal = false;  // reset before ALLOW_DEBUG may override; avoids stale value from prior init
 
   subaru_common_init();
 
@@ -260,22 +362,55 @@ static safety_config subaru_init(uint16_t param) {
   subaru_longitudinal = GET_FLAG(param, SUBARU_PARAM_LONGITUDINAL);
 #endif
 
+  brake_intercept_release_countdown = 0;
+  subaru_brake_hold_active_countdown = 0;
+
   safety_config ret;
   if (subaru_gen2) {
     ret = subaru_longitudinal ? BUILD_SAFETY_CFG(subaru_gen2_rx_checks, SUBARU_GEN2_LONG_TX_MSGS) : \
                                 BUILD_SAFETY_CFG(subaru_gen2_rx_checks, SUBARU_GEN2_TX_MSGS);
   } else {
-    ret = subaru_longitudinal ? BUILD_SAFETY_CFG(subaru_rx_checks, SUBARU_LONG_TX_MSGS) : \
-          subaru_stop_and_go  ? BUILD_SAFETY_CFG(subaru_rx_checks, subaru_stop_and_go_tx_msgs) : \
-                                BUILD_SAFETY_CFG(subaru_rx_checks, SUBARU_TX_MSGS);
+    if (subaru_longitudinal) {
+      if (subaru_stop_and_go && subaru_brake_intercept) {
+        ret = BUILD_SAFETY_CFG(subaru_rx_checks, subaru_long_sng_brake_intercept_tx_msgs);
+      } else if (subaru_brake_intercept) {
+        ret = BUILD_SAFETY_CFG(subaru_rx_checks, subaru_long_brake_intercept_tx_msgs);
+      } else {
+        ret = BUILD_SAFETY_CFG(subaru_rx_checks, SUBARU_LONG_TX_MSGS);
+      }
+    } else if (subaru_stop_and_go && subaru_brake_intercept) {
+      ret = BUILD_SAFETY_CFG(subaru_rx_checks, subaru_sng_brake_intercept_tx_msgs);
+    } else if (subaru_stop_and_go) {
+      ret = BUILD_SAFETY_CFG(subaru_rx_checks, subaru_stop_and_go_tx_msgs);
+    } else if (subaru_brake_intercept) {
+      ret = BUILD_SAFETY_CFG(subaru_rx_checks, subaru_brake_intercept_tx_msgs);
+    } else {
+      ret = BUILD_SAFETY_CFG(subaru_rx_checks, SUBARU_TX_MSGS);
+    }
   }
   return ret;
+}
+
+// The TX entries set disable_static_blocking=true, so this hook reimposes the relay block on
+// ES_Brake (cam→main) and Brake_Status (main→cam) only while a hold is being asserted.
+static bool subaru_fwd_hook(int bus_num, int addr) {
+  bool block = false;
+  if (subaru_brake_intercept && (subaru_brake_hold_active_countdown > 0)) {
+    if (((uint32_t)bus_num == SUBARU_CAM_BUS) && ((uint32_t)addr == MSG_SUBARU_ES_Brake)) {
+      block = true;  // hide Eyesight's ES_Brake from braking module during hold
+    }
+    if (((uint32_t)bus_num == SUBARU_MAIN_BUS) && ((uint32_t)addr == MSG_SUBARU_Brake_Status)) {
+      block = true;  // hide braking module's hold-induced ES_Brake bit from Eyesight
+    }
+  }
+  return block;
 }
 
 const safety_hooks subaru_hooks = {
   .init = subaru_init,
   .rx = subaru_rx_hook,
   .tx = subaru_tx_hook,
+  .fwd = subaru_fwd_hook,
   .get_counter = subaru_get_counter,
   .get_checksum = subaru_get_checksum,
   .compute_checksum = subaru_compute_checksum,

--- a/opendbc/safety/modes/subaru_common.h
+++ b/opendbc/safety/modes/subaru_common.h
@@ -10,10 +10,15 @@
 extern bool subaru_stop_and_go;
 bool subaru_stop_and_go = false;
 
+extern bool subaru_brake_intercept;
+bool subaru_brake_intercept = false;
+
 void subaru_common_init(void) {
   const uint16_t SUBARU_PARAM_SP_STOP_AND_GO = 1;
+  const uint16_t SUBARU_PARAM_SP_BRAKE_INTERCEPT = 4;  // bit 2 (bit 1 reserved/unused)
 
   subaru_stop_and_go = GET_FLAG(current_safety_param_sp, SUBARU_PARAM_SP_STOP_AND_GO);
+  subaru_brake_intercept = GET_FLAG(current_safety_param_sp, SUBARU_PARAM_SP_BRAKE_INTERCEPT);
 }
 
 /*

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -900,6 +900,11 @@ class SafetyTest(SafetyTestBase):
               continue
             if attr.startswith('TestSubaruPreglobal') and current_test.startswith('TestSubaruPreglobal'):
               continue
+            # brake_intercept is a SUBARU_IMPREZA_2020 mode and shares the Subaru main-bus TX set (ES_LKAS, etc.)
+            if 'BrakeIntercept' in attr and current_test.startswith('TestSubaru'):
+              continue
+            if 'BrakeIntercept' in current_test and attr.startswith('TestSubaru'):
+              continue
             if {attr, current_test}.issubset({'TestVolkswagenPqSafety', 'TestVolkswagenPqStockSafety', 'TestVolkswagenPqLongSafety'}):
               continue
             if {attr, current_test}.issubset({'TestGmCameraSafety', 'TestGmCameraLongitudinalSafety', 'TestGmAscmSafety',

--- a/opendbc/safety/tests/test_subaru_brake_hold.py
+++ b/opendbc/safety/tests/test_subaru_brake_hold.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""Panda safety tests for the Subaru brake-intercept feature.
+
+Settling window: tx of non-zero ES_Brake is allowed while the rx countdown is
+< BRAKE_INTERCEPT_RELEASE_FRAMES (3), i.e. for the first 2 moving Wheel_Speeds frames.
+"""
+import unittest
+
+from opendbc.car.structs import CarParams
+from opendbc.car.subaru.values import SubaruSafetyFlags
+from opendbc.safety.tests.libsafety import libsafety_py
+from opendbc.safety.tests.common import CANPackerSafety
+from opendbc.sunnypilot.car.subaru.values_ext import SubaruSafetyFlagsSP
+
+from opendbc.safety.tests.test_subaru import (
+  SubaruMsg,
+  SUBARU_MAIN_BUS,
+  SUBARU_CAM_BUS,
+  lkas_tx_msgs,
+  TestSubaruSafetyBase,
+)
+
+# Brake_Pedal (0x139) and Brake_Status (0x13C) are not in the SubaruMsg enum
+MSG_SUBARU_Brake_Pedal  = 0x139
+MSG_SUBARU_Brake_Status = 0x13C
+
+BRAKE_INTERCEPT_RELEASE_FRAMES = 3  # must match C #define
+SUBARU_BRAKE_HOLD_ACTIVE_FRAMES = 4  # must match C #define (~80ms at 50Hz Wheel_Speeds)
+
+
+class TestSubaruBrakeIntercept(TestSubaruSafetyBase):
+  # Gen1, no SnG, brake_intercept SP param set.
+  SAFETY_MODEL = CarParams.SafetyModel.subaru
+  FLAGS = 0
+  SP_PARAM = SubaruSafetyFlagsSP.BRAKE_INTERCEPT
+
+  # No Brake_Pedal: openpilot never sends it in this no-SnG config, so the relay must forward the
+  # car's real Brake_Pedal (0x139) to Eyesight. A leftover allowlist entry statically blocked that
+  # relay → Eyesight RX timeout → fault at power-on (hardware-confirmed 2026-05-22).
+  TX_MSGS = (
+    lkas_tx_msgs(SUBARU_MAIN_BUS)
+    + [[SubaruMsg.ES_Brake,      SUBARU_MAIN_BUS]]
+    + [[MSG_SUBARU_Brake_Status, SUBARU_CAM_BUS]]
+  )
+
+  RELAY_MALFUNCTION_ADDRS = {
+    SUBARU_MAIN_BUS: (
+      SubaruMsg.ES_LKAS,
+      SubaruMsg.ES_DashStatus,
+      SubaruMsg.ES_LKAS_State,
+      SubaruMsg.ES_Infotainment,
+      SubaruMsg.ES_Brake,
+    ),
+    SUBARU_CAM_BUS: (
+      MSG_SUBARU_Brake_Status,
+    ),
+  }
+
+  # ES_Brake (CAM→MAIN) and Brake_Status (MAIN→CAM) are conditionally blocked only while a hold is
+  # actively injected (see TestSubaruBrakeHoldFwd); Brake_Pedal is never blocked.
+  FWD_BLACKLISTED_ADDRS = {
+    SUBARU_CAM_BUS: [
+      SubaruMsg.ES_LKAS,
+      SubaruMsg.ES_DashStatus,
+      SubaruMsg.ES_LKAS_State,
+      SubaruMsg.ES_Infotainment,
+    ],
+  }
+
+  def setUp(self):
+    self.packer = CANPackerSafety("subaru_global_2017_generated")
+    self.safety = libsafety_py.libsafety
+    self.safety.set_current_safety_param_sp(self.SP_PARAM)  # must precede set_safety_hooks
+    self.safety.set_safety_hooks(CarParams.SafetyModel.subaru, self.FLAGS)
+    self.safety.init_tests()
+
+  # ── helpers ────────────────────────────────────────────────────────────────
+
+  def _engage(self):
+    # standard engagement: ACC. Long subclass overrides to MADS-only.
+    self.safety.set_controls_allowed(True)
+
+  def _es_brake_msg(self, pressure):
+    return self.packer.make_can_msg_safety("ES_Brake", SUBARU_MAIN_BUS, {"Brake_Pressure": pressure})
+
+  def _set_standstill(self):
+    for _ in range(BRAKE_INTERCEPT_RELEASE_FRAMES + 1):
+      self._rx(self._speed_msg(0))
+
+  def _set_moving(self, frames=1):
+    for _ in range(frames):
+      self._rx(self._speed_msg(10))
+
+  def _exhaust_hysteresis(self):
+    self._set_moving(frames=BRAKE_INTERCEPT_RELEASE_FRAMES + 1)
+
+  def test_tx_hook_on_wrong_safety_mode(self):
+    # brake-intercept variants share all LKAS TX msgs by design — skip the cross-class overlap check
+    raise unittest.SkipTest("Subaru brake-intercept variants share LKAS TX msgs")
+
+  # ── zero pressure always allowed (passthrough) ──────────────────────────────
+
+  def test_es_brake_zero_allowed_at_standstill(self):
+    self._set_standstill()
+    self.safety.set_controls_allowed(True)
+    self.assertTrue(self._tx(self._es_brake_msg(0)))
+
+  def test_es_brake_zero_allowed_when_moving(self):
+    self._exhaust_hysteresis()
+    self.safety.set_controls_allowed(True)
+    self.assertTrue(self._tx(self._es_brake_msg(0)))
+
+  def test_es_brake_zero_allowed_when_moving_controls_off(self):
+    self._exhaust_hysteresis()
+    self.safety.set_controls_allowed(False)
+    self.assertTrue(self._tx(self._es_brake_msg(0)))
+
+  # ── non-zero pressure at standstill: pressure × authority matrix ─────────────
+
+  def test_standstill_pressure_authority(self):
+    # (pressure, controls_allowed, controls_lateral, expected) — blocked only when BOTH authorities
+    # are off or pressure exceeds max_brake (600)
+    for pressure, controls, lateral, allowed in [
+      (100, True, False, True),
+      (600, True, False, True),   # boundary == max_brake
+      (601, True, False, False),  # > max_brake
+      (100, False, False, False),  # neither ACC nor MADS
+      (100, False, True, True),   # MADS-only
+    ]:
+      with self.subTest(pressure=pressure, controls=controls, lateral=lateral):
+        self._set_standstill()
+        self.safety.set_controls_allowed(controls)
+        self.safety.set_controls_allowed_lateral(lateral)
+        self.assertEqual(allowed, self._tx(self._es_brake_msg(pressure)))
+
+  def test_es_brake_allowed_with_gas_pressed_at_standstill(self):
+    # gas is intentionally NOT gated on the AVH path: the same ES_Brake frame carries Eyesight's AEB
+    # echo (must never be gas-gated) and braking is the fail-safe direction
+    self._set_standstill()
+    self.safety.set_controls_allowed(False)
+    self.safety.set_controls_allowed_lateral(True)
+    self._rx(self._user_gas_msg(2000))
+    self.assertTrue(self._tx(self._es_brake_msg(600)))
+
+  # ── non-zero pressure when moving (hysteresis / settling window) ─────────────
+
+  def test_es_brake_nonzero_blocked_when_moving(self):
+    self._set_standstill()
+    self._engage()
+    self._exhaust_hysteresis()
+    self.assertFalse(self._tx(self._es_brake_msg(100)))
+
+  def test_es_brake_nonzero_blocked_when_moving_various_pressures(self):
+    self._set_standstill()
+    self._engage()
+    self._exhaust_hysteresis()
+    for pressure in (1, 50, 100, 300, 600):
+      with self.subTest(pressure=pressure):
+        self.assertFalse(self._tx(self._es_brake_msg(pressure)))
+
+  def test_settling_window_frame_gating(self):
+    # countdown < BRAKE_INTERCEPT_RELEASE_FRAMES (3) → settling → allowed; capped at 3 once moving
+    for frames, allowed in [(1, True), (2, True), (BRAKE_INTERCEPT_RELEASE_FRAMES, False),
+                            (BRAKE_INTERCEPT_RELEASE_FRAMES + 1, False)]:
+      with self.subTest(frames=frames):
+        self._set_standstill()
+        self._engage()
+        self._set_moving(frames=frames)
+        self.assertEqual(allowed, self._tx(self._es_brake_msg(100)))
+
+  def test_race_a_countdown_resets_on_standstill(self):
+    self._set_standstill()
+    self._engage()
+    self._exhaust_hysteresis()
+    self.assertFalse(self._tx(self._es_brake_msg(100)))
+    self._set_standstill()  # countdown reset → allowed again
+    self.assertTrue(self._tx(self._es_brake_msg(100)))
+
+  def test_race_a_hysteresis_does_not_bypass_controls_allowed(self):
+    self._set_standstill()
+    self.safety.set_controls_allowed(False)
+    self.safety.set_controls_allowed_lateral(False)
+    self._set_moving(frames=1)  # inside settling window
+    self.assertFalse(self._tx(self._es_brake_msg(100)))
+
+  def test_race_a_hysteresis_does_not_bypass_max_brake(self):
+    self._set_standstill()
+    self.safety.set_controls_allowed(True)
+    self._set_moving(frames=1)  # inside settling window
+    self.assertFalse(self._tx(self._es_brake_msg(601)))
+
+  # ── Brake_Status (0x13C) masking tx_hook ────────────────────────────────────
+
+  def _brake_status_msg(self, es_brake_bit):
+    return self.packer.make_can_msg_safety("Brake_Status", SUBARU_CAM_BUS, {"ES_Brake": es_brake_bit, "Brake": 0})
+
+  def test_brake_status_allowed_es_brake_cleared(self):
+    self.safety.set_controls_allowed(True)
+    self.assertTrue(self._tx(self._brake_status_msg(0)))
+
+  def test_brake_status_blocked_es_brake_set(self):
+    # panda must never forward a Brake_Status with ES_Brake=1 to Eyesight
+    self.safety.set_controls_allowed(True)
+    self.assertFalse(self._tx(self._brake_status_msg(1)))
+
+  def test_brake_status_allowed_controls_off(self):
+    # masking is not gated on controls_allowed — always needed during hold
+    self.safety.set_controls_allowed(False)
+    self.assertTrue(self._tx(self._brake_status_msg(0)))
+
+  def test_brake_status_blocked_without_brake_intercept(self):
+    self.safety.set_current_safety_param_sp(0)
+    self.safety.set_safety_hooks(CarParams.SafetyModel.subaru, 0)
+    self.safety.init_tests()
+    self.safety.set_controls_allowed(True)
+    self.assertFalse(self._tx(self._brake_status_msg(0)))
+
+  def test_no_brake_intercept_es_brake_blocked(self):
+    # no brake_intercept SP param → ES_Brake not in allowlist → blocked unconditionally
+    self.safety.set_current_safety_param_sp(0)
+    self.safety.set_safety_hooks(CarParams.SafetyModel.subaru, 0)
+    self.safety.init_tests()
+    self._set_standstill()
+    self.safety.set_controls_allowed(True)
+    self.assertFalse(self._tx(self._es_brake_msg(0)))
+    self.assertFalse(self._tx(self._es_brake_msg(100)))
+
+  def test_gen2_with_brake_intercept_sp_param_es_brake_blocked(self):
+    # gen2 ignores SP brake_intercept — ES_Brake must not be in the allowlist
+    self.safety.set_current_safety_param_sp(SubaruSafetyFlagsSP.BRAKE_INTERCEPT)
+    self.safety.set_safety_hooks(CarParams.SafetyModel.subaru, SubaruSafetyFlags.GEN2)
+    self.safety.init_tests()
+    self._set_standstill()
+    self.safety.set_controls_allowed(True)
+    self.assertFalse(self._tx(self._es_brake_msg(0)))
+    self.assertFalse(self._tx(self._es_brake_msg(100)))
+
+  # ── Conditional forwarding ───────────────────────────────────────────────────
+  # ES_Brake (CAM→MAIN) and Brake_Status (MAIN→CAM) are blocked only while a hold is actively
+  # injected. Unconditional blocking would starve Eyesight's native ACC braking and trip its
+  # ~566ms Cruise_Fault watchdog. Active-hold state is a Wheel_Speeds-paced countdown set on TX.
+
+  def _brake_status_mask_msg(self):
+    return self.packer.make_can_msg_safety("Brake_Status", SUBARU_CAM_BUS, {"ES_Brake": 0, "Brake": 0})
+
+  def _tx_hold_pressure(self):
+    self._set_standstill()
+    self.safety.set_controls_allowed(True)
+    self.assertTrue(self._tx(self._es_brake_msg(400)))
+
+  def _tx_brake_status_mask(self):
+    self.safety.set_controls_allowed(True)
+    self.assertTrue(self._tx(self._brake_status_mask_msg()))
+
+  def _pump_wheel_speeds(self, n):
+    for _ in range(n):
+      self._rx(self._speed_msg(0))
+
+  def test_fwd_es_brake_cam_to_main_allowed_when_idle(self):
+    self.assertEqual(SUBARU_MAIN_BUS, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+
+  def test_fwd_brake_status_main_to_cam_allowed_when_idle(self):
+    self.assertEqual(SUBARU_CAM_BUS, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+  def test_fwd_es_brake_cam_to_main_blocked_after_hold_tx(self):
+    self._tx_hold_pressure()
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+
+  def test_fwd_brake_status_main_to_cam_blocked_after_hold_tx(self):
+    self._tx_hold_pressure()
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+  def test_fwd_brake_status_main_to_cam_blocked_after_mask_tx(self):
+    self._tx_brake_status_mask()
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+  def test_fwd_remains_blocked_during_countdown(self):
+    self._tx_hold_pressure()
+    for k in range(SUBARU_BRAKE_HOLD_ACTIVE_FRAMES - 1):
+      self._pump_wheel_speeds(1)
+      with self.subTest(after_pumps=k + 1):
+        self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+        self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+  def test_fwd_restored_after_countdown_expires(self):
+    self._tx_hold_pressure()
+    self._pump_wheel_speeds(SUBARU_BRAKE_HOLD_ACTIVE_FRAMES)
+    self.assertEqual(SUBARU_MAIN_BUS, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+    self.assertEqual(SUBARU_CAM_BUS, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+  def test_fwd_blocked_retriggered_by_subsequent_hold_tx(self):
+    self._tx_hold_pressure()
+    self._pump_wheel_speeds(SUBARU_BRAKE_HOLD_ACTIVE_FRAMES)
+    self.assertEqual(SUBARU_MAIN_BUS, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+    self._set_standstill()
+    self.assertTrue(self._tx(self._es_brake_msg(400)))
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+
+  def test_fwd_not_blocked_after_zero_pressure_tx(self):
+    # zero-pressure TX must not engage the hold gate
+    self.safety.set_controls_allowed(True)
+    self.assertTrue(self._tx(self._es_brake_msg(0)))
+    self.assertEqual(SUBARU_MAIN_BUS, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+    self.assertEqual(SUBARU_CAM_BUS, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+  def test_fwd_es_brake_restored_for_aeb_after_hold_release(self):
+    # after hold release + countdown decay, Eyesight's AEB ES_Brake (cam→main) must relay again
+    self._tx_hold_pressure()
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+    self._pump_wheel_speeds(SUBARU_BRAKE_HOLD_ACTIVE_FRAMES)
+    self.assertEqual(SUBARU_MAIN_BUS, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+
+  def test_fwd_brake_pedal_main_to_cam_forwarded(self):
+    # regression: no-SnG config never sends Brake_Pedal, so the relay forwards the car's real frame
+    # MAIN→CAM. A leftover allowlist entry statically blocked it → Eyesight fault (hardware 2026-05-22)
+    self.assertEqual(SUBARU_CAM_BUS, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Pedal))
+
+  def test_fwd_brake_pedal_not_gated_during_hold(self):
+    # subaru_fwd_hook never gates Brake_Pedal — only ES_Brake / Brake_Status are hold-gated
+    self._tx_hold_pressure()
+    self.assertEqual(SUBARU_CAM_BUS, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Pedal))
+
+
+class TestSubaruSnGBrakeIntercept(TestSubaruBrakeIntercept):
+  # Gen1, SnG + brake_intercept. SnG re-sends Throttle and Brake_Pedal on the cam bus.
+  SP_PARAM = SubaruSafetyFlagsSP.STOP_AND_GO | SubaruSafetyFlagsSP.BRAKE_INTERCEPT
+
+  TX_MSGS = (
+    lkas_tx_msgs(SUBARU_MAIN_BUS)
+    + [[SubaruMsg.Throttle,        SUBARU_CAM_BUS]]
+    + [[MSG_SUBARU_Brake_Pedal,    SUBARU_CAM_BUS]]
+    + [[SubaruMsg.ES_Brake,        SUBARU_MAIN_BUS]]
+    + [[MSG_SUBARU_Brake_Status,   SUBARU_CAM_BUS]]
+  )
+
+  RELAY_MALFUNCTION_ADDRS = {
+    SUBARU_MAIN_BUS: (
+      SubaruMsg.ES_LKAS,
+      SubaruMsg.ES_DashStatus,
+      SubaruMsg.ES_LKAS_State,
+      SubaruMsg.ES_Infotainment,
+      SubaruMsg.ES_Brake,
+    ),
+    SUBARU_CAM_BUS: (
+      SubaruMsg.Throttle,
+      MSG_SUBARU_Brake_Pedal,
+      MSG_SUBARU_Brake_Status,
+    ),
+  }
+
+  FWD_BLACKLISTED_ADDRS = {
+    SUBARU_CAM_BUS: [
+      SubaruMsg.ES_LKAS,
+      SubaruMsg.ES_DashStatus,
+      SubaruMsg.ES_LKAS_State,
+      SubaruMsg.ES_Infotainment,
+    ],
+    SUBARU_MAIN_BUS: [
+      SubaruMsg.Throttle,
+      MSG_SUBARU_Brake_Pedal,
+    ],
+  }
+
+  def test_no_brake_intercept_es_brake_blocked(self):
+    # re-init with ONLY SnG (no brake_intercept) → ES_Brake not in allowlist
+    self.safety.set_current_safety_param_sp(SubaruSafetyFlagsSP.STOP_AND_GO)
+    self.safety.set_safety_hooks(CarParams.SafetyModel.subaru, 0)
+    self.safety.init_tests()
+    self._set_standstill()
+    self.safety.set_controls_allowed(True)
+    self.assertFalse(self._tx(self._es_brake_msg(0)))
+    self.assertFalse(self._tx(self._es_brake_msg(100)))
+
+  def test_gen2_with_brake_intercept_sp_param_es_brake_blocked(self):
+    self.safety.set_current_safety_param_sp(
+      SubaruSafetyFlagsSP.STOP_AND_GO | SubaruSafetyFlagsSP.BRAKE_INTERCEPT
+    )
+    self.safety.set_safety_hooks(CarParams.SafetyModel.subaru, SubaruSafetyFlags.GEN2)
+    self.safety.init_tests()
+    self._set_standstill()
+    self.safety.set_controls_allowed(True)
+    self.assertFalse(self._tx(self._es_brake_msg(0)))
+    self.assertFalse(self._tx(self._es_brake_msg(100)))
+
+  def test_brake_status_blocked_without_brake_intercept(self):
+    self.safety.set_current_safety_param_sp(SubaruSafetyFlagsSP.STOP_AND_GO)
+    self.safety.set_safety_hooks(CarParams.SafetyModel.subaru, 0)
+    self.safety.init_tests()
+    self.safety.set_controls_allowed(True)
+    self.assertFalse(self._tx(self._brake_status_msg(0)))
+
+  # SnG sends Brake_Pedal on cam → it IS in the allowlist → relay statically blocked MAIN→CAM.
+  # Override the no-SnG regression/invariant, which expect the relay open.
+  def test_fwd_brake_pedal_main_to_cam_forwarded(self):
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Pedal))
+
+  def test_fwd_brake_pedal_not_gated_during_hold(self):
+    self._tx_hold_pressure()
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Pedal))
+
+
+class TestSubaruLongBrakeIntercept(TestSubaruBrakeIntercept):
+  # Gen1, alpha long enabled, brake_intercept, no SnG. Hardware-failing scenario
+  # (route dde08cad3a74cd94|00000012): alpha long ON, MADS active, op long not engaged,
+  # AVH wants to hold at standstill. ES_Brake=600 at standstill+MADS must be accepted.
+  FLAGS = SubaruSafetyFlags.LONG
+
+  TX_MSGS = (
+    lkas_tx_msgs(SUBARU_MAIN_BUS)
+    + [[SubaruMsg.ES_Brake,        SUBARU_MAIN_BUS]]
+    + [[SubaruMsg.ES_Status,       SUBARU_MAIN_BUS]]
+    + [[MSG_SUBARU_Brake_Status,   SUBARU_CAM_BUS]]
+  )
+
+  RELAY_MALFUNCTION_ADDRS = {
+    SUBARU_MAIN_BUS: (
+      SubaruMsg.ES_LKAS, SubaruMsg.ES_DashStatus, SubaruMsg.ES_LKAS_State,
+      SubaruMsg.ES_Infotainment, SubaruMsg.ES_Brake, SubaruMsg.ES_Distance, SubaruMsg.ES_Status,
+    ),
+    SUBARU_CAM_BUS: (
+      MSG_SUBARU_Brake_Status,
+    ),
+  }
+
+  # In long mode op long is the sole sender of ES_Brake/ES_Distance/ES_Status on main, so all three
+  # are statically blocked cam→main. Brake_Pedal is not blocked (relay forwards the car's real frame).
+  FWD_BLACKLISTED_ADDRS = {
+    SUBARU_CAM_BUS: [
+      SubaruMsg.ES_LKAS, SubaruMsg.ES_DashStatus, SubaruMsg.ES_LKAS_State,
+      SubaruMsg.ES_Infotainment, SubaruMsg.ES_Brake, SubaruMsg.ES_Distance, SubaruMsg.ES_Status,
+    ],
+  }
+
+  def _engage(self):
+    # MADS-only (no ACC): in long mode controls_allowed=True would take the long path, masking the
+    # AVH standstill invariant
+    self.safety.set_controls_allowed(False)
+    self.safety.set_controls_allowed_lateral(True)
+
+  def test_avh_hold_pressure_allowed_with_mads_at_standstill(self):
+    # alpha long on, op long NOT engaged, MADS active, standstill → AVH may inject ES_Brake=600
+    self._set_standstill()
+    self.safety.set_controls_allowed(False)
+    self.safety.set_controls_allowed_lateral(True)
+    self.assertTrue(self._tx(self._es_brake_msg(600)))
+
+  def test_avh_hold_pressure_blocked_when_moving_without_acc(self):
+    # MADS-only: brake injection allowed only at standstill (+ settling); blocked once rolling
+    self._exhaust_hysteresis()
+    self.safety.set_controls_allowed(False)
+    self.safety.set_controls_allowed_lateral(True)
+    self.assertFalse(self._tx(self._es_brake_msg(600)))
+
+  def test_long_path_unchanged_when_acc_engaged(self):
+    # adding the AVH union must not narrow the long path: ACC engaged → full ES_Brake range while rolling
+    self._exhaust_hysteresis()
+    self.safety.set_controls_allowed(True)
+    self.safety.set_controls_allowed_lateral(True)
+    self.assertTrue(self._tx(self._es_brake_msg(100)))
+
+  def test_brake_pressure_above_max_rejected(self):
+    self._set_standstill()
+    self.safety.set_controls_allowed(True)
+    self.safety.set_controls_allowed_lateral(True)
+    self.assertFalse(self._tx(self._es_brake_msg(601)))
+
+  def test_no_controls_no_lateral_blocks_nonzero_brake(self):
+    self._set_standstill()
+    self.safety.set_controls_allowed(False)
+    self.safety.set_controls_allowed_lateral(False)
+    self.assertFalse(self._tx(self._es_brake_msg(100)))
+    self.assertTrue(self._tx(self._es_brake_msg(0)))
+
+  def test_brake_status_mask_allowed_with_brake_intercept(self):
+    self.assertTrue(self._tx(self._brake_status_msg(0)))
+
+  def test_brake_status_mask_with_es_brake_bit_set_rejected(self):
+    self.assertFalse(self._tx(self._brake_status_msg(1)))
+
+  def test_gen2_long_with_brake_intercept_uses_gen2_long_path(self):
+    # gen2 has no AVH — Brake_Status must not be in the gen2 long allowlist
+    self.safety.set_current_safety_param_sp(SubaruSafetyFlagsSP.BRAKE_INTERCEPT)
+    self.safety.set_safety_hooks(CarParams.SafetyModel.subaru,
+                                  SubaruSafetyFlags.LONG | SubaruSafetyFlags.GEN2)
+    self.safety.init_tests()
+    self.assertFalse(self._tx(self._brake_status_msg(0)))
+
+  # ── Fwd overrides: in long mode ES_Brake cam→main is ALWAYS statically blocked (op long owns it) ─
+
+  def test_fwd_es_brake_cam_to_main_allowed_when_idle(self):
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+
+  def test_fwd_restored_after_countdown_expires(self):
+    self._tx_hold_pressure()
+    self._pump_wheel_speeds(SUBARU_BRAKE_HOLD_ACTIVE_FRAMES)
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+    self.assertEqual(SUBARU_CAM_BUS, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+  def test_fwd_blocked_retriggered_by_subsequent_hold_tx(self):
+    self._tx_hold_pressure()
+    self._pump_wheel_speeds(SUBARU_BRAKE_HOLD_ACTIVE_FRAMES)
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+    self._set_standstill()
+    self.assertTrue(self._tx(self._es_brake_msg(400)))
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+
+  def test_fwd_not_blocked_after_zero_pressure_tx(self):
+    self.safety.set_controls_allowed(True)
+    self.assertTrue(self._tx(self._es_brake_msg(0)))
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+    self.assertEqual(SUBARU_CAM_BUS, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+  def test_fwd_remains_blocked_during_countdown(self):
+    self._tx_hold_pressure()
+    for k in range(SUBARU_BRAKE_HOLD_ACTIVE_FRAMES - 1):
+      self._pump_wheel_speeds(1)
+      with self.subTest(after_pumps=k + 1):
+        self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+        self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+  def test_fwd_es_brake_restored_for_aeb_after_hold_release(self):
+    # long mode: ES_Brake cam→main stays blocked even after hold release — op long handles AEB
+    self._tx_hold_pressure()
+    self._pump_wheel_speeds(SUBARU_BRAKE_HOLD_ACTIVE_FRAMES)
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_CAM_BUS, SubaruMsg.ES_Brake))
+
+  def test_long_path_brake_does_not_bump_countdown(self):
+    # op-long braking (long_valid path) must not bump the hold countdown, else Eyesight's
+    # Brake_Status relay starves during sustained ACC braking → ACC faults
+    self.safety.set_controls_allowed(True)
+    self._set_moving(frames=BRAKE_INTERCEPT_RELEASE_FRAMES + 1)
+    self.assertTrue(self._tx(self._es_brake_msg(300)))
+    self.assertEqual(SUBARU_CAM_BUS, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+  def test_sustained_long_braking_does_not_starve_brake_status_relay(self):
+    # 30 consecutive op-long brake TXes must not starve the Brake_Status relay (stay moving so
+    # avh_valid=False → long path only)
+    self.safety.set_controls_allowed(True)
+    self._set_moving(frames=BRAKE_INTERCEPT_RELEASE_FRAMES + 1)
+    for _ in range(30):
+      self.assertTrue(self._tx(self._es_brake_msg(300)))
+      self._rx(self._speed_msg(10))
+    self.assertEqual(SUBARU_CAM_BUS, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+  def test_safety_reinit_resets_countdown(self):
+    # re-calling set_safety_hooks must clear the active-hold countdown immediately
+    self._tx_hold_pressure()
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+    self.safety.set_current_safety_param_sp(SubaruSafetyFlagsSP.BRAKE_INTERCEPT)
+    self.safety.set_safety_hooks(CarParams.SafetyModel.subaru, self.FLAGS)
+    self.safety.init_tests()
+    self.assertEqual(SUBARU_CAM_BUS, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Status))
+
+
+class TestSubaruLongSnGBrakeIntercept(TestSubaruLongBrakeIntercept):
+  # Gen1, alpha long + SnG + brake_intercept — the on-device config for SUBARU_IMPREZA_2020.
+  SP_PARAM = SubaruSafetyFlagsSP.STOP_AND_GO | SubaruSafetyFlagsSP.BRAKE_INTERCEPT
+
+  TX_MSGS = (
+    lkas_tx_msgs(SUBARU_MAIN_BUS)
+    + [[SubaruMsg.ES_Brake,        SUBARU_MAIN_BUS]]
+    + [[SubaruMsg.ES_Status,       SUBARU_MAIN_BUS]]
+    + [[SubaruMsg.Throttle,        SUBARU_CAM_BUS]]
+    + [[MSG_SUBARU_Brake_Pedal,    SUBARU_CAM_BUS]]
+    + [[MSG_SUBARU_Brake_Status,   SUBARU_CAM_BUS]]
+  )
+
+  RELAY_MALFUNCTION_ADDRS = {
+    SUBARU_MAIN_BUS: (
+      SubaruMsg.ES_LKAS, SubaruMsg.ES_DashStatus, SubaruMsg.ES_LKAS_State,
+      SubaruMsg.ES_Infotainment, SubaruMsg.ES_Brake, SubaruMsg.ES_Distance, SubaruMsg.ES_Status,
+    ),
+    SUBARU_CAM_BUS: (
+      SubaruMsg.Throttle, MSG_SUBARU_Brake_Pedal, MSG_SUBARU_Brake_Status,
+    ),
+  }
+
+  FWD_BLACKLISTED_ADDRS = {
+    SUBARU_CAM_BUS: [
+      SubaruMsg.ES_LKAS, SubaruMsg.ES_DashStatus, SubaruMsg.ES_LKAS_State,
+      SubaruMsg.ES_Infotainment, SubaruMsg.ES_Brake, SubaruMsg.ES_Distance, SubaruMsg.ES_Status,
+    ],
+    SUBARU_MAIN_BUS: [
+      SubaruMsg.Throttle, MSG_SUBARU_Brake_Pedal,
+    ],
+  }
+
+  def test_gen2_long_with_brake_intercept_uses_gen2_long_path(self):
+    self.safety.set_current_safety_param_sp(
+      SubaruSafetyFlagsSP.STOP_AND_GO | SubaruSafetyFlagsSP.BRAKE_INTERCEPT
+    )
+    self.safety.set_safety_hooks(CarParams.SafetyModel.subaru,
+                                  SubaruSafetyFlags.LONG | SubaruSafetyFlags.GEN2)
+    self.safety.init_tests()
+    self.assertFalse(self._tx(self._brake_status_msg(0)))
+
+  # SnG sends Brake_Pedal on cam → in allowlist → relay statically blocked MAIN→CAM
+  def test_fwd_brake_pedal_main_to_cam_forwarded(self):
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Pedal))
+
+  def test_fwd_brake_pedal_not_gated_during_hold(self):
+    self._tx_hold_pressure()
+    self.assertEqual(-1, self.safety.safety_fwd_hook(SUBARU_MAIN_BUS, MSG_SUBARU_Brake_Pedal))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/opendbc/sunnypilot/car/interfaces.py
+++ b/opendbc/sunnypilot/car/interfaces.py
@@ -87,6 +87,7 @@ def setup_interfaces(CI, CP: structs.CarParams, CP_SP: structs.CarParamsSP,
   _initialize_coop_steering(CP, CP_SP, params_dict)
   _initialize_radar_tracks(CP, CP_SP, can_recv, can_send)
   _initialize_stop_and_go(CP, CP_SP, params_dict)
+  _initialize_brake_intercept(CP, CP_SP, params_dict)
   _initialize_toyota(CP, CP_SP, params_dict)
 
 
@@ -131,6 +132,14 @@ def _initialize_stop_and_go(CP: structs.CarParams, CP_SP: structs.CarParamsSP, p
       CP_SP.flags |= SubaruFlagsSP.STOP_AND_GO_MANUAL_PARKING_BRAKE.value
     if stop_and_go or stop_and_go_manual_parking_brake:
       CP_SP.safetyParam |= SubaruSafetyFlagsSP.STOP_AND_GO
+
+
+def _initialize_brake_intercept(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params_dict: dict[str, str]) -> None:
+  if CP.brand == 'subaru' and CP.alphaLongitudinalAvailable:
+    # alphaLongitudinalAvailable excludes: GEN2, PREGLOBAL, LKAS_ANGLE, HYBRID
+    if int(params_dict.get("SubaruAutoVehicleHold", 0)) == 1:
+      CP.flags |= SubaruFlags.BRAKE_HOLD.value
+      CP_SP.safetyParam |= SubaruSafetyFlagsSP.BRAKE_INTERCEPT  # OR-assign: preserves SnG bit if set
 
 
 def _initialize_toyota(CP: structs.CarParams, CP_SP: structs.CarParamsSP, params_dict: dict[str, str]) -> None:

--- a/opendbc/sunnypilot/car/subaru/subarucan_ext.py
+++ b/opendbc/sunnypilot/car/subaru/subarucan_ext.py
@@ -66,3 +66,16 @@ def create_brake_pedal(packer, CP, brake_pedal_msg, send_resume):
     values["Speed"] = 1 if CP.flags & SubaruFlags.PREGLOBAL else 3
 
   return packer.make_can_msg("Brake_Pedal", CanBus.camera, values)
+
+
+def create_brake_status_hold(packer, brake_status_msg: dict):
+  """Send Brake_Status to camera bus with ES_Brake cleared so Eyesight never sees the
+  braking module's ES_Brake feedback during a hold (else its ~566ms fault watchdog trips).
+  Reuses the received COUNTER since we replace a forwarded-unmodified frame.
+  """
+  values = {
+    s: brake_status_msg[s]
+    for s in ["CHECKSUM", "COUNTER", "Signal1", "ES_Brake", "Signal2", "Brake", "Signal3"]
+  }
+  values["ES_Brake"] = 0  # hide braking-module feedback from Eyesight
+  return packer.make_can_msg("Brake_Status", CanBus.camera, values)

--- a/opendbc/sunnypilot/car/subaru/tests/test_brake_hold_controller.py
+++ b/opendbc/sunnypilot/car/subaru/tests/test_brake_hold_controller.py
@@ -1,0 +1,567 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from opendbc.can import CANParser
+from opendbc.car import structs, Bus
+from opendbc.car.subaru.values import DBC, CAR, SubaruFlags, CarControllerParams
+from opendbc.car.subaru.carcontroller import CarController
+from opendbc.car.interfaces import GearShifter
+
+_DUMMY_MSG = ("ES_Brake", bytes(8), 0)
+_DUMMY_BS_MSG = ("Brake_Status", bytes(8), 2)
+_DBC_NAMES = DBC[CAR.SUBARU_IMPREZA_2020.value]
+
+
+def make_CP(brake_hold: bool = True, long_control: bool = False) -> structs.CarParams:
+  CP = structs.CarParams()
+  CP.carFingerprint = CAR.SUBARU_IMPREZA_2020.value
+  CP.openpilotLongitudinalControl = long_control
+  if brake_hold:
+    CP.flags = SubaruFlags.BRAKE_HOLD.value | SubaruFlags.STEER_RATE_LIMITED.value
+  else:
+    CP.flags = SubaruFlags.STEER_RATE_LIMITED.value
+  return CP
+
+
+def make_CC(lat_active: bool = False, long_active: bool = False, enabled: bool = False, cancel: bool = False):
+  # capnp reader so actuators.as_builder() works in update()
+  cc_b = structs.CarControl()
+  cc_b.enabled = enabled
+  cc_b.latActive = lat_active
+  cc_b.longActive = long_active
+  cc_b.cruiseControl.cancel = cancel
+  return cc_b.as_reader()
+
+
+def make_CC_SP(mads_enabled: bool = True, mads_active: bool = True) -> structs.CarControlSP:
+  CC_SP = structs.CarControlSP()
+  CC_SP.mads.enabled = mads_enabled
+  CC_SP.mads.active = mads_active
+  return CC_SP
+
+
+def make_CS(
+  vEgoRaw: float = 0.0,
+  brakePressed: bool = False,
+  gasPressed: bool = False,
+  standstill: bool = True,
+  gear: GearShifter = GearShifter.drive,
+  aeb_status: int = 0,
+  es_brake_msg=None,
+  cruise_enabled: bool = False,
+  cruise_available: bool = False,
+):
+  CS = MagicMock()
+  CS.out = MagicMock()
+  CS.out.vEgoRaw = vEgoRaw
+  CS.out.brakePressed = brakePressed
+  CS.out.gasPressed = gasPressed
+  CS.out.standstill = standstill
+  CS.out.gearShifter = gear
+  CS.out.steeringTorque = 0
+  CS.out.steeringRateDeg = 0
+  CS.out.cruiseState = MagicMock()
+  CS.out.cruiseState.enabled = cruise_enabled
+  CS.out.cruiseState.available = cruise_available
+  CS.es_distance_msg = {"COUNTER": 0, "Cruise_Cancel": False, "Cruise_Throttle": 0,
+                         "Close_Distance": 0.0}
+  CS.es_dashstatus_msg = {}
+  CS.es_lkas_state_msg = {}
+  CS.es_infotainment_msg = {}
+  CS.es_status_msg = {}
+  if es_brake_msg is None:
+    CS.es_brake_msg = {
+      "AEB_Status": aeb_status, "CHECKSUM": 0, "Signal1": 0,
+      "Brake_Pressure": 0, "Cruise_Brake_Lights": 0,
+      "Cruise_Brake_Fault": 0, "Cruise_Brake_Active": 0,
+      "Cruise_Activated": 0, "Signal3": 0,
+    }
+  else:
+    CS.es_brake_msg = es_brake_msg
+  CS.brake_status_msg = {
+    "CHECKSUM": 0, "COUNTER": 0, "Signal1": 0, "ES_Brake": 0,
+    "Signal2": 0, "Brake": 0, "Signal3": 0,
+  }
+  CS.cruise_button = 0
+  CS.throttle_msg = {}
+  CS.brake_pedal_msg = {}
+  return CS
+
+
+def make_ctrl(brake_hold: bool = True, long_control: bool = False) -> CarController:
+  CP = make_CP(brake_hold=brake_hold, long_control=long_control)
+  CP_SP = structs.CarParamsSP()  # no SnG flags → SnGCarController disabled
+  return CarController(_DBC_NAMES, CP, CP_SP)
+
+
+# patch the unrelated send fns that choke on the mock CS data
+_STEERING_PATCH = patch("opendbc.car.subaru.subarucan.create_steering_control", return_value=_DUMMY_MSG)
+_DASHSTATUS_PATCH = patch("opendbc.car.subaru.subarucan.create_es_dashstatus", return_value=_DUMMY_MSG)
+_LKAS_STATE_PATCH = patch("opendbc.car.subaru.subarucan.create_es_lkas_state", return_value=_DUMMY_MSG)
+_BRAKE_HOLD_PATCH = "opendbc.car.subaru.subarucan.create_es_brake_hold"
+_BRAKE_STATUS_HOLD_PATCH = "opendbc.sunnypilot.car.subaru.subarucan_ext.create_brake_status_hold"
+
+
+def run_update(ctrl, CC=None, CC_SP=None, CS=None):
+  CC = CC or make_CC()
+  CC_SP = CC_SP or make_CC_SP()
+  CS = CS or make_CS()
+  with _STEERING_PATCH, _DASHSTATUS_PATCH, _LKAS_STATE_PATCH, \
+       patch(_BRAKE_HOLD_PATCH, return_value=_DUMMY_MSG) as mock_bh, \
+       patch(_BRAKE_STATUS_HOLD_PATCH, return_value=_DUMMY_BS_MSG):
+    ctrl.update(CC, CC_SP, CS, 0)
+  return mock_bh
+
+
+def run_update_capture_both(ctrl, CC=None, CC_SP=None, CS=None):
+  CC = CC or make_CC()
+  CC_SP = CC_SP or make_CC_SP()
+  CS = CS or make_CS()
+  with _STEERING_PATCH, _DASHSTATUS_PATCH, _LKAS_STATE_PATCH, \
+       patch(_BRAKE_HOLD_PATCH, return_value=_DUMMY_MSG) as mock_bh, \
+       patch(_BRAKE_STATUS_HOLD_PATCH, return_value=_DUMMY_BS_MSG) as mock_bsh:
+    ctrl.update(CC, CC_SP, CS, 0)
+  return mock_bh, mock_bsh
+
+
+class TestBrakeHoldController(unittest.TestCase):
+
+  def _get_brake_value(self, mock_bh):
+    self.assertTrue(mock_bh.called, "create_es_brake_hold was not called")
+    return mock_bh.call_args[0][4]  # (packer, frame, es_brake_msg, long_enabled, brake_value)
+
+  def _prime(self, ctrl):
+    ctrl.frame = 1  # odd frame: priming runs but frame%5 != 0 (isolates priming from hold/reset)
+    run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True), CS=make_CS(vEgoRaw=0.5, brakePressed=True))
+    self.assertTrue(ctrl._brake_hold_primed, "precondition: must be primed")
+
+  def test_primed_false_on_init(self):
+    self.assertFalse(make_ctrl()._brake_hold_primed)
+
+  def test_priming_conditions(self):
+    # priming requires mads.enabled AND vEgoRaw<1.5 AND brakePressed AND gear not park/reverse
+    for mads_enabled, vego, brake, gear, expected in [
+      (False, 0.5, True, GearShifter.drive, False),  # mads disabled
+      (True, 0.5, False, GearShifter.drive, False),  # brake not pressed
+      (True, 2.0, True, GearShifter.drive, False),  # speed >= 1.5
+      (True, 0.5, True, GearShifter.park, False),  # park
+      (True, 0.5, True, GearShifter.reverse, False),  # reverse
+      (True, 0.5, True, GearShifter.drive, True),  # all met → primed
+    ]:
+      with self.subTest(mads_enabled=mads_enabled, vego=vego, brake=brake, gear=gear):
+        ctrl = make_ctrl()
+        ctrl.frame = 1
+        run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=mads_enabled),
+                   CS=make_CS(vEgoRaw=vego, brakePressed=brake, gear=gear))
+        self.assertIs(ctrl._brake_hold_primed, expected)
+
+  def test_holding_conditions(self):
+    for primed, standstill, brake, gas, gear, holds in [
+      (False, True, False, False, GearShifter.drive, False),  # not primed
+      (True, False, False, False, GearShifter.drive, False),  # not standstill — ACC may be braking
+      (True, True, True, False, GearShifter.drive, True),   # seamless hold, foot still on pedal
+      (True, True, False, True,  GearShifter.drive, False),  # gas pressed
+      (True, True, False, False, GearShifter.park, False),  # park
+      (True, True, False, False, GearShifter.drive, True),   # all met
+    ]:
+      with self.subTest(primed=primed, standstill=standstill, brake=brake, gas=gas, gear=gear):
+        ctrl = make_ctrl()
+        ctrl.frame = 0  # frame%5 == 0: hold branch runs
+        ctrl._brake_hold_primed = primed
+        mock_bh = run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+                             CS=make_CS(standstill=standstill, brakePressed=brake, gasPressed=gas, gear=gear))
+        if holds:
+          self.assertEqual(self._get_brake_value(mock_bh), CarControllerParams.BRAKE_HOLD_PRESSURE)
+        else:
+          self.assertFalse(mock_bh.called)
+
+  def test_aeb_vs_hold_brake_value(self):
+    for primed, standstill, vego, aeb_status, eyesight_pressure, expected in [
+      (True, True, 0.0, 8, 450, 450),  # AEB overrides hold → echo Eyesight pressure
+      (True, True, 0.0, 0, 0, CarControllerParams.BRAKE_HOLD_PRESSURE),  # no AEB, holding → hold pressure
+      (False, False, 8.0, 4, 600, 600),  # AEB while moving, not holding → passthrough
+    ]:
+      with self.subTest(aeb_status=aeb_status, eyesight_pressure=eyesight_pressure):
+        ctrl = make_ctrl()
+        ctrl.frame = 0
+        ctrl._brake_hold_primed = primed
+        es_msg = {"AEB_Status": aeb_status, "CHECKSUM": 0, "Signal1": 0, "Brake_Pressure": eyesight_pressure,
+                  "Cruise_Brake_Lights": 0, "Cruise_Brake_Fault": 0, "Cruise_Brake_Active": 0,
+                  "Cruise_Activated": 0, "Signal3": 0}
+        mock_bh = run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+                             CS=make_CS(standstill=standstill, vEgoRaw=vego, brakePressed=False,
+                                        gasPressed=False, es_brake_msg=es_msg))
+        self.assertEqual(self._get_brake_value(mock_bh), expected)
+
+  def test_latch_reset(self):
+    # prime at frame 1, then trigger a reset condition inside the frame%5==0 block
+    for mads_enabled, cs_kwargs in [
+      (True,  dict(vEgoRaw=0.5, gasPressed=True, standstill=True)),  # gas pressed
+      (False, dict(vEgoRaw=0.5, standstill=True)),                   # mads disabled
+      (True,  dict(vEgoRaw=1.0, standstill=False)),                  # speed above threshold
+    ]:
+      with self.subTest(mads_enabled=mads_enabled, cs_kwargs=cs_kwargs):
+        ctrl = make_ctrl()
+        self._prime(ctrl)
+        ctrl.frame = 5
+        run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=mads_enabled), CS=make_CS(brakePressed=False, **cs_kwargs))
+        self.assertFalse(ctrl._brake_hold_primed)
+
+  def test_none_guard_no_send(self):
+    ctrl = make_ctrl()
+    ctrl.frame = 0
+    CS = make_CS()
+    CS.es_brake_msg = None
+    mock_bh = run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True), CS=CS)
+    self.assertFalse(mock_bh.called)
+
+  def test_brake_hold_flag_required(self):
+    ctrl = make_ctrl(brake_hold=False)
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    mock_bh = run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True), CS=make_CS(standstill=True))
+    self.assertFalse(mock_bh.called)
+
+  def test_hold_frame_mod5_gating(self):
+    # ES_Brake hold recomputes/sends only on frame%5 == 0
+    for frame, called in [(3, False), (0, True), (5, True)]:
+      with self.subTest(frame=frame):
+        ctrl = make_ctrl()
+        ctrl.frame = frame
+        ctrl._brake_hold_primed = True
+        mock_bh = run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+                             CS=make_CS(standstill=True, brakePressed=False))
+        self.assertIs(mock_bh.called, called)
+
+  def test_mask_sends_without_es_brake_at_frame2(self):
+    # Brake_Status mask (frame%2==0) and ES_Brake hold (frame%5==0) run on independent cadences;
+    # _brake_hold_active carries over from a prior frame%5==0 hold
+    ctrl = make_ctrl()
+    ctrl._brake_hold_primed = True
+    ctrl._brake_hold_active = True
+    ctrl.frame = 2
+    mock_bh, mock_bsh = run_update_capture_both(
+      ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(standstill=True, brakePressed=False, gasPressed=False),
+    )
+    self.assertFalse(mock_bh.called)
+    self.assertTrue(mock_bsh.called)
+
+  def test_real_packer_emits_hold_pressure(self):
+    # real create_es_brake_hold + CANPacker — catches controller↔packer DBC drift the mocks can't
+    ctrl = make_ctrl()
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    with _STEERING_PATCH, _DASHSTATUS_PATCH, _LKAS_STATE_PATCH, \
+         patch(_BRAKE_STATUS_HOLD_PATCH, return_value=_DUMMY_BS_MSG):
+      _, can_sends = ctrl.update(
+        make_CC(), make_CC_SP(mads_enabled=True),
+        make_CS(standstill=True, brakePressed=False, gasPressed=False), 0,
+      )
+    es_brake = [m for m in can_sends if isinstance(m[0], int) and m[0] == 0x220]
+    self.assertEqual(len(es_brake), 1, "exactly one real ES_Brake frame expected")
+    parser = CANParser(_DBC_NAMES[Bus.pt], [("ES_Brake", 0)], 0)
+    parser.update([0, es_brake])
+    self.assertEqual(parser.vl["ES_Brake"]["Brake_Pressure"], CarControllerParams.BRAKE_HOLD_PRESSURE)
+
+
+# Regression for route dde08cad3a74cd94/0000004d--8360486eb1 seg 3 (2026-05-11): the carcontroller
+# unconditionally injected ES_Brake=0 and the Brake_Status mask while Eyesight ACC was braking from
+# rolling speed, hiding the braking module's feedback and tripping Eyesight's ~566ms Cruise_Fault
+# watchdog. Invariant: when NOT holding AND NOT echoing AEB, transmit neither 0x220 nor 0x13C.
+class TestACCInterferenceRegression(unittest.TestCase):
+
+  def test_brake_hold_active_false_on_init(self):
+    ctrl = make_ctrl()
+    self.assertTrue(hasattr(ctrl, "_brake_hold_active"))
+    self.assertFalse(ctrl._brake_hold_active)
+
+  def test_no_es_brake_hold_when_acc_braking_not_holding(self):
+    # Eyesight ACC braking from rolling speed (Brake_Pressure>0), not holding → stay out of the way
+    ctrl = make_ctrl(long_control=False)
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = False
+    acc_braking_msg = {
+      "AEB_Status": 0, "CHECKSUM": 0, "Signal1": 0, "Brake_Pressure": 40,
+      "Cruise_Brake_Lights": 1, "Cruise_Brake_Fault": 0, "Cruise_Brake_Active": 1,
+      "Cruise_Activated": 1, "Signal3": 0,
+    }
+    CC = make_CC(enabled=True, long_active=False)
+    mock_bh, mock_bsh = run_update_capture_both(
+      ctrl, CC=CC, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(vEgoRaw=2.32, standstill=False, brakePressed=False,
+                 gasPressed=False, es_brake_msg=acc_braking_msg),
+    )
+    self.assertFalse(mock_bh.called)
+    self.assertFalse(mock_bsh.called)
+
+  def test_no_brake_status_mask_when_not_holding(self):
+    ctrl = make_ctrl()
+    ctrl.frame = 0  # frame%2 == 0 — would otherwise trigger the mask send
+    ctrl._brake_hold_primed = False
+    mock_bh, mock_bsh = run_update_capture_both(
+      ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(standstill=False, brakePressed=False, gasPressed=False, vEgoRaw=5.0),
+    )
+    self.assertFalse(mock_bh.called)
+    self.assertFalse(mock_bsh.called)
+
+  def test_holding_path_unchanged_regression(self):
+    ctrl = make_ctrl()
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    mock_bh, mock_bsh = run_update_capture_both(
+      ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(standstill=True, brakePressed=False, gasPressed=False),
+    )
+    self.assertTrue(mock_bh.called)
+    self.assertFalse(mock_bh.call_args[0][3])  # stock Eyesight ACC — forward fault verbatim
+    self.assertEqual(mock_bh.call_args[0][4], CarControllerParams.BRAKE_HOLD_PRESSURE)
+    self.assertTrue(mock_bsh.called)
+
+  def test_aeb_passthrough_keeps_both_messages(self):
+    # AEB is an active intercept: echo ES_Brake (full AEB authority) AND keep the mask
+    ctrl = make_ctrl()
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = False
+    aeb_msg = {
+      "AEB_Status": 4, "CHECKSUM": 0, "Signal1": 0, "Brake_Pressure": 600,
+      "Cruise_Brake_Lights": 1, "Cruise_Brake_Fault": 0, "Cruise_Brake_Active": 1,
+      "Cruise_Activated": 0, "Signal3": 0,
+    }
+    mock_bh, mock_bsh = run_update_capture_both(
+      ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(standstill=False, vEgoRaw=8.0, brakePressed=False,
+                 gasPressed=False, es_brake_msg=aeb_msg),
+    )
+    self.assertTrue(mock_bh.called)
+    self.assertEqual(mock_bh.call_args[0][4], 600)
+    self.assertTrue(mock_bsh.called)
+
+  def test_brake_hold_active_tracks_state(self):
+    # _brake_hold_active must be True if and only if (holding or AEB)
+    ctrl = make_ctrl()
+    ctrl.frame = 0
+
+    ctrl._brake_hold_primed = False
+    acc_msg = {"AEB_Status": 0, "CHECKSUM": 0, "Signal1": 0, "Brake_Pressure": 40,
+               "Cruise_Brake_Lights": 1, "Cruise_Brake_Fault": 0, "Cruise_Brake_Active": 1,
+               "Cruise_Activated": 1, "Signal3": 0}
+    run_update_capture_both(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+                            CS=make_CS(standstill=False, vEgoRaw=2.3, es_brake_msg=acc_msg))
+    self.assertFalse(ctrl._brake_hold_active)
+
+    ctrl._brake_hold_primed = True
+    ctrl.frame = 0
+    run_update_capture_both(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+                            CS=make_CS(standstill=True, brakePressed=False, gasPressed=False))
+    self.assertTrue(ctrl._brake_hold_active)
+
+    ctrl._brake_hold_primed = False
+    ctrl.frame = 0
+    aeb_msg = {"AEB_Status": 4, "CHECKSUM": 0, "Signal1": 0, "Brake_Pressure": 600,
+               "Cruise_Brake_Lights": 1, "Cruise_Brake_Fault": 0, "Cruise_Brake_Active": 1,
+               "Cruise_Activated": 0, "Signal3": 0}
+    run_update_capture_both(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+                            CS=make_CS(standstill=False, vEgoRaw=8.0, es_brake_msg=aeb_msg))
+    self.assertTrue(ctrl._brake_hold_active)
+
+  def test_brake_status_msg_none_guard(self):
+    ctrl = make_ctrl()
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    CS = make_CS(standstill=True, brakePressed=False, gasPressed=False)
+    CS.brake_status_msg = None
+    mock_bh, mock_bsh = run_update_capture_both(ctrl, CC_SP=make_CC_SP(mads_enabled=True), CS=CS)
+    self.assertTrue(mock_bh.called)  # ES_Brake hold still goes out
+    self.assertFalse(mock_bsh.called)  # mask gated on brake_status_msg presence
+
+
+# AVH owns ES_Brake when openpilotLongitudinalControl=True AND longActive=False; it must yield
+# (create_es_brake instead) when longActive=True. The Brake_Status mask follows the same gating.
+_ES_BRAKE_PATCH = "opendbc.car.subaru.subarucan.create_es_brake"
+_ES_STATUS_PATCH = "opendbc.car.subaru.subarucan.create_es_status"
+_ES_DISTANCE_PATCH = "opendbc.car.subaru.subarucan.create_es_distance"
+
+
+def _run_long_branch(ctrl, CC, CC_SP=None, CS=None):
+  CC_SP = CC_SP or make_CC_SP()
+  CS = CS or make_CS()
+  with _STEERING_PATCH, _DASHSTATUS_PATCH, _LKAS_STATE_PATCH, \
+       patch(_ES_STATUS_PATCH, return_value=_DUMMY_MSG), \
+       patch(_ES_DISTANCE_PATCH, return_value=_DUMMY_MSG), \
+       patch(_ES_BRAKE_PATCH, return_value=_DUMMY_MSG) as mock_eb, \
+       patch(_BRAKE_HOLD_PATCH, return_value=_DUMMY_MSG) as mock_bh, \
+       patch(_BRAKE_STATUS_HOLD_PATCH, return_value=_DUMMY_BS_MSG) as mock_bsh:
+    ctrl.update(CC, CC_SP, CS, 0)
+  return mock_eb, mock_bh, mock_bsh
+
+
+class TestAlphaLongCoexistence(unittest.TestCase):
+
+  def test_avh_fires_when_alpha_long_enabled_but_not_active(self):
+    ctrl = make_ctrl(long_control=True, brake_hold=True)
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    CC = make_CC(enabled=False, long_active=False)
+    mock_eb, mock_bh, _ = _run_long_branch(
+      ctrl, CC, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(standstill=True, brakePressed=False, gasPressed=False),
+    )
+    self.assertTrue(mock_bh.called, "create_es_brake_hold must run when alpha long enabled but inactive")
+    self.assertFalse(mock_eb.called, "create_es_brake must NOT run when AVH is asserting ES_Brake")
+    self.assertTrue(mock_bh.call_args[0][3])  # alpha long enabled — clear the latched fault
+    self.assertEqual(mock_bh.call_args[0][4], CarControllerParams.BRAKE_HOLD_PRESSURE)
+
+  def test_avh_yields_when_alpha_long_active(self):
+    ctrl = make_ctrl(long_control=True, brake_hold=True)
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    CC = make_CC(enabled=True, long_active=True)
+    mock_eb, mock_bh, _ = _run_long_branch(
+      ctrl, CC, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(standstill=True, brakePressed=False, gasPressed=False),
+    )
+    self.assertFalse(mock_bh.called, "create_es_brake_hold must yield to op long when long_active=True")
+    self.assertTrue(mock_eb.called, "create_es_brake must run when long is actively in control")
+
+  def test_brake_status_mask_under_alpha_long_when_avh_active(self):
+    ctrl = make_ctrl(long_control=True, brake_hold=True)
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    CC = make_CC(enabled=False, long_active=False)
+    _, _, mock_bsh = _run_long_branch(
+      ctrl, CC, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(standstill=True, brakePressed=False, gasPressed=False),
+    )
+    self.assertTrue(mock_bsh.called, "Brake_Status mask must run when AVH active under alpha long")
+
+  def test_brake_status_mask_yields_under_alpha_long_active(self):
+    ctrl = make_ctrl(long_control=True, brake_hold=True)
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    CC = make_CC(enabled=True, long_active=True)
+    _, _, mock_bsh = _run_long_branch(
+      ctrl, CC, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(standstill=True, brakePressed=False, gasPressed=False),
+    )
+    self.assertFalse(mock_bsh.called, "Brake_Status mask must not run when long is active")
+
+
+# AVH must never prime or hold while Eyesight ACC is engaged (cruiseState.enabled); the guard
+# gates only on .enabled, not .available, and AEB echo stays independent of ACC.
+class TestACCDeference(unittest.TestCase):
+
+  def test_no_prime_when_acc_enabled(self):
+    ctrl = make_ctrl()
+    ctrl.frame = 1
+    run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+               CS=make_CS(vEgoRaw=0.5, brakePressed=True, cruise_enabled=True))
+    self.assertFalse(ctrl._brake_hold_primed)
+
+  def test_no_prime_when_acc_enabled_rolling(self):
+    ctrl = make_ctrl()
+    ctrl.frame = 1
+    run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+               CS=make_CS(vEgoRaw=1.2, brakePressed=True, cruise_enabled=True))
+    self.assertFalse(ctrl._brake_hold_primed)
+
+  def test_no_hold_when_acc_enabled(self):
+    ctrl = make_ctrl()
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    mock_bh = run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+                         CS=make_CS(standstill=True, gasPressed=False, cruise_enabled=True))
+    self.assertFalse(mock_bh.called)
+
+  def test_release_when_acc_enabled(self):
+    # primed while ACC off, then ACC engages → latch clears on the frame%5==0 reset
+    ctrl = make_ctrl()
+    ctrl.frame = 1
+    run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+               CS=make_CS(vEgoRaw=0.5, brakePressed=True, cruise_enabled=False))
+    self.assertTrue(ctrl._brake_hold_primed, "precondition: must be primed")
+
+    ctrl.frame = 5
+    run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+               CS=make_CS(standstill=True, gasPressed=False, cruise_enabled=True))
+    self.assertFalse(ctrl._brake_hold_primed)
+
+  def test_no_brake_status_mask_when_acc_enabled(self):
+    ctrl = make_ctrl()
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    ctrl._brake_hold_active = True
+    mock_bh, mock_bsh = run_update_capture_both(
+      ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(standstill=True, gasPressed=False, cruise_enabled=True),
+    )
+    self.assertFalse(mock_bsh.called)
+
+  def test_mask_clears_when_acc_engages_midcadence(self):
+    # frame=2: mask cadence (frame%2==0) but no state recompute (frame%5!=0); carried-over
+    # active flag must not trigger the mask once ACC is engaged
+    ctrl = make_ctrl()
+    ctrl._brake_hold_primed = True
+    ctrl._brake_hold_active = True
+    ctrl.frame = 2
+    mock_bh, mock_bsh = run_update_capture_both(
+      ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(standstill=True, gasPressed=False, aeb_status=0, cruise_enabled=True),
+    )
+    self.assertFalse(mock_bsh.called)
+
+  def test_acc_available_but_not_enabled_still_holds(self):
+    # guard gates only on .enabled — main-on (available) but not engaged must still hold
+    ctrl = make_ctrl()
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    mock_bh = run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+                         CS=make_CS(standstill=True, gasPressed=False,
+                                    cruise_available=True, cruise_enabled=False))
+    self.assertTrue(mock_bh.called)
+    self.assertEqual(mock_bh.call_args[0][4], CarControllerParams.BRAKE_HOLD_PRESSURE)
+
+  def test_aeb_echo_unaffected_by_acc(self):
+    # AEB authority is independent of ACC engagement
+    ctrl = make_ctrl()
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = False
+    aeb_msg = {
+      "AEB_Status": 4, "CHECKSUM": 0, "Signal1": 0, "Brake_Pressure": 600,
+      "Cruise_Brake_Lights": 1, "Cruise_Brake_Fault": 0, "Cruise_Brake_Active": 1,
+      "Cruise_Activated": 0, "Signal3": 0,
+    }
+    mock_bh = run_update(ctrl, CC_SP=make_CC_SP(mads_enabled=True),
+                         CS=make_CS(standstill=False, vEgoRaw=8.0, brakePressed=False,
+                                    gasPressed=False, es_brake_msg=aeb_msg, cruise_enabled=True))
+    self.assertTrue(mock_bh.called)
+    self.assertEqual(mock_bh.call_args[0][4], 600)
+
+  def test_no_hold_when_acc_enabled_alpha_long(self):
+    ctrl = make_ctrl(long_control=True)
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    CC = make_CC(enabled=False, long_active=False)
+    mock_eb, mock_bh, _ = _run_long_branch(
+      ctrl, CC, CC_SP=make_CC_SP(mads_enabled=True),
+      CS=make_CS(standstill=True, brakePressed=False, gasPressed=False, cruise_enabled=True),
+    )
+    self.assertFalse(mock_bh.called)
+
+  def test_real_packer_no_es_brake_when_acc_enabled(self):
+    ctrl = make_ctrl()
+    ctrl.frame = 0
+    ctrl._brake_hold_primed = True
+    with _STEERING_PATCH, _DASHSTATUS_PATCH, _LKAS_STATE_PATCH, \
+         patch(_BRAKE_STATUS_HOLD_PATCH, return_value=_DUMMY_BS_MSG):
+      _, can_sends = ctrl.update(
+        make_CC(), make_CC_SP(mads_enabled=True),
+        make_CS(standstill=True, brakePressed=False, gasPressed=False, cruise_enabled=True), 0,
+      )
+    es_brake_frames = [m for m in can_sends if isinstance(m[0], int) and m[0] == 0x220]
+    self.assertEqual(len(es_brake_frames), 0, "no ES_Brake frame must be emitted when ACC is engaged")
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/opendbc/sunnypilot/car/subaru/tests/test_brake_intercept_init.py
+++ b/opendbc/sunnypilot/car/subaru/tests/test_brake_intercept_init.py
@@ -1,0 +1,54 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from opendbc.car import structs
+from opendbc.car.subaru.values import SubaruFlags
+from opendbc.sunnypilot.car.interfaces import setup_interfaces
+from opendbc.sunnypilot.car.subaru.values_ext import SubaruSafetyFlagsSP
+
+
+def _run_setup(params: dict, brand: str = 'subaru', alpha_long_available: bool = True):
+  CP = structs.CarParams()
+  CP.brand = brand
+  CP.alphaLongitudinalAvailable = alpha_long_available
+  CP_SP = structs.CarParamsSP()
+  setup_interfaces(MagicMock(), CP, CP_SP, params_list=[params])
+  return CP, CP_SP
+
+
+class TestBrakeInterceptInit(unittest.TestCase):
+  def test_flag_not_set_when_param_off(self):
+    CP, CP_SP = _run_setup({"SubaruAutoVehicleHold": "0"})
+    self.assertFalse(CP.flags & SubaruFlags.BRAKE_HOLD)
+    self.assertFalse(CP_SP.safetyParam & SubaruSafetyFlagsSP.BRAKE_INTERCEPT)
+
+  def test_flag_set_when_param_on(self):
+    CP, CP_SP = _run_setup({"SubaruAutoVehicleHold": "1"})
+    self.assertTrue(CP.flags & SubaruFlags.BRAKE_HOLD)
+    self.assertTrue(CP_SP.safetyParam & SubaruSafetyFlagsSP.BRAKE_INTERCEPT)
+
+  def test_flag_not_set_when_ineligible_even_if_param_on(self):
+    CP, CP_SP = _run_setup({"SubaruAutoVehicleHold": "1"}, alpha_long_available=False)
+    self.assertFalse(CP.flags & SubaruFlags.BRAKE_HOLD)
+    self.assertFalse(CP_SP.safetyParam & SubaruSafetyFlagsSP.BRAKE_INTERCEPT)
+
+  def test_brake_intercept_preserves_sng_bit(self):
+    # BRAKE_INTERCEPT is OR-added, must not clobber the SnG safety bit
+    _, CP_SP = _run_setup({"SubaruStopAndGo": "1", "SubaruAutoVehicleHold": "1"})
+    self.assertTrue(CP_SP.safetyParam & SubaruSafetyFlagsSP.STOP_AND_GO)
+    self.assertTrue(CP_SP.safetyParam & SubaruSafetyFlagsSP.BRAKE_INTERCEPT)
+
+  def test_non_subaru_brand_untouched(self):
+    CP, CP_SP = _run_setup({"SubaruAutoVehicleHold": "1"}, brand='toyota')
+    self.assertFalse(CP.flags & SubaruFlags.BRAKE_HOLD)
+    self.assertFalse(CP_SP.safetyParam & SubaruSafetyFlagsSP.BRAKE_INTERCEPT)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/opendbc/sunnypilot/car/subaru/values_ext.py
+++ b/opendbc/sunnypilot/car/subaru/values_ext.py
@@ -10,6 +10,7 @@ from enum import IntFlag
 
 class SubaruSafetyFlagsSP:
   STOP_AND_GO = 1
+  BRAKE_INTERCEPT = 4  # bit 2 (bit 1 reserved/unused)
 
 
 class SubaruFlagsSP(IntFlag):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.codespell]
 quiet-level = 3
-ignore-words-list = "alo,ba,bu,deque,hda,grey,arange"
+ignore-words-list = "alo,ba,bu,deque,hda,grey,arange,Wen"
 builtin = "clear,rare,informal,code,names,en-GB_to_en-US"
 check-hidden = true
 


### PR DESCRIPTION
### Subaru Automatic Vehicle Hold (AVH)

Adds standstill brake-hold for `SUBARU_IMPREZA_2020` (Crosstrek/Impreza/XV 2020–23, Global Gen1 non-hybrid) by injecting `ES_Brake` (`0x220`) at `Brake_Pressure = 600` via a velocity-primed latch, arbitrated against op-long, with a reworked panda safety mode that permits the hold frame only at standstill and within authority. Hardware-validated on both alpha-long and stock Eyesight ACC.

**Eligibility:** gated by the `SubaruAutoVehicleHold` param + `alphaLongitudinalAvailable` (excludes Gen2 / Pre-global / LKAS_ANGLE / Hybrid).

**Safety:** new `brake_intercept` mode; ES_Brake/Brake_Status TX with conditional relay blocking via `subaru_fwd_hook` (only during a hold, so Eyesight's native ACC drives the relays when idle). Bounded by authority + pressure limit (`max_brake = 600`) + standstill. Test coverage: settling-window edges, countdown aging, fwd_hook block/restore, no-authority, Gen2 exclusion, AEB-after-release.

**Drive-by fix (note for reviewers):** this branch also resets `subaru_longitudinal = false` at the top of `subaru_init`. That static is only assigned inside `#ifdef ALLOW_DEBUG`, so across repeated inits it could keep a stale `true` and select the wrong TX allowlist (most visibly across test cases sharing a process). The reset gives each init a clean baseline; ALLOW_DEBUG still overrides it. Independent of AVH, just included here.