### PR TITLE
add fw for 2026 Kia EV9

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1063,6 +1063,7 @@ FW_VERSIONS = {
       b'\xf1\x00MV__ RDR -----      1.00 1.03 99110-DO000         ',
       b'\xf1\x00MV__ RDR -----      1.00 1.04 99110-DO000         ',
       b'\xf1\x00MV__ RDR -----      1.00 1.02 99110-DO700         ',
+      b'\xf1\x00MV__ RDR -----      1.00 1.04 99110-DO700         ',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00MV  MFC  AT KOR LHD 1.00 1.01 99211-DO000 230419',
@@ -1071,6 +1072,7 @@ FW_VERSIONS = {
       b'\xf1\x00MV  MFC  AT CAN LHD 1.00 1.00 99211-DO100 240403',
       b'\xf1\x00MV  MFC  AT USA LHD 1.00 1.01 99211-XA000 241023',
       b'\xf1\x00MV  MFC  AT CAN LHD 1.00 1.01 99211-DO100 241023',
+      b'\xf1\x00MV  MFC  AT USA LHD 1.00 1.02 99211-XA000 241223',
     ],
   },
   CAR.HYUNDAI_IONIQ_5: {


### PR DESCRIPTION
Add firmware for a 2026 Kia EV9.


464ac801173f6dca/0000000c--0da0c04907/0