### PR TITLE
Revert "deprecate carState.brake" for Honda Gas Interceptor

### DIFF
--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -203,6 +203,7 @@ class CarState(CarStateBase, CarStateExt):
 
     # Gets rid of Pedal Grinding noise when brake is pressed at slow speeds for some models
     if self.CP.carFingerprint in (CAR.HONDA_PILOT, CAR.HONDA_RIDGELINE):
+      ret.brakeDEPRECATED = cp.vl["VSA_STATUS"]["USER_BRAKE"]
       if ret.brakeDEPRECATED > 0.1:
         ret.brakePressed = True
 

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -198,12 +198,12 @@ class CarState(CarStateBase, CarStateExt):
         self.brake_switch_prev = brake_switch
       ret.brakePressed = (cp.vl["POWERTRAIN_DATA"]["BRAKE_PRESSED"] != 0) or self.brake_switch_active
 
+    ret.brakeDEPRECATED = cp.vl["VSA_STATUS"]["USER_BRAKE"]
     ret.cruiseState.enabled = cp.vl["POWERTRAIN_DATA"]["ACC_STATUS"] != 0
     ret.cruiseState.available = bool(cp.vl[self.car_state_scm_msg]["MAIN_ON"])
 
     # Gets rid of Pedal Grinding noise when brake is pressed at slow speeds for some models
     if self.CP.carFingerprint in (CAR.HONDA_PILOT, CAR.HONDA_RIDGELINE):
-      ret.brakeDEPRECATED = cp.vl["VSA_STATUS"]["USER_BRAKE"]
       if ret.brakeDEPRECATED > 0.1:
         ret.brakePressed = True
 


### PR DESCRIPTION
Needed to complete impact of reverting opendbc pr 3425

Requires https://github.com/sunnypilot/sunnypilot/pull/1860 to pass CI tests, see [here](https://github.com/mvl-boston/opendbc/pull/572).