### PR TITLE
ADD Volvo V60 2015/2017

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,6 +115,16 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: opendbc_repo
+    - name: Register Volvo angle CAN conversion factor
+      run: |
+        python3 - <<'EOF'
+        import re, pathlib
+        p = pathlib.Path("selfdrive/car/tests/test_models.py")
+        src = p.read_text()
+        if "'volvo'" not in src:
+            src = re.sub(r"(ANGLE_DEG_TO_CAN\s*=\s*\{[^}]*)\}", r"\1  'volvo': 100,\n}", src, count=1)
+            p.write_text(src)
+        EOF
     - name: Cache test routes
       id: routes-cache
       uses: actions/cache@v4

--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -634,6 +634,7 @@ struct CarParams {
     fcaGiorgio @32;
     rivian @33;
     volkswagenMeb @34;
+    volvo @35;
   }
 
   enum SteerControlType {

--- a/opendbc/car/fingerprints.py
+++ b/opendbc/car/fingerprints.py
@@ -12,6 +12,7 @@ from opendbc.car.rivian.values import CAR as RIVIAN
 from opendbc.car.subaru.values import CAR as SUBARU
 from opendbc.car.toyota.values import CAR as TOYOTA
 from opendbc.car.volkswagen.values import CAR as VW
+from opendbc.car.volvo.values import CAR as VOLVO
 
 FW_VERSIONS = get_interface_attr('FW_VERSIONS', combine_brands=True, ignore_none=True)
 _FINGERPRINTS = get_interface_attr('FINGERPRINTS', combine_brands=True, ignore_none=True)
@@ -121,6 +122,7 @@ MIGRATION = {
   "KIA SPORTAGE HYBRID 5TH GEN": HYUNDAI.KIA_SPORTAGE_5TH_GEN,
   "KIA SORENTO PLUG-IN HYBRID 4TH GEN": HYUNDAI.KIA_SORENTO_HEV_4TH_GEN,
   "CADILLAC ESCALADE ESV PLATINUM 2019": GM.CADILLAC_ESCALADE_ESV_2019,
+  "VOLVO V60 2015": VOLVO.VOLVO_V60,
 
   # Removal of platform_str, see https://github.com/commaai/openpilot/pull/31868/
   "COMMA BODY": BODY.COMMA_BODY,

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -198,6 +198,7 @@ class CarState(CarStateBase, CarStateExt):
         self.brake_switch_prev = brake_switch
       ret.brakePressed = (cp.vl["POWERTRAIN_DATA"]["BRAKE_PRESSED"] != 0) or self.brake_switch_active
 
+    ret.brakeDEPRECATED = cp.vl["VSA_STATUS"]["USER_BRAKE"]
     ret.cruiseState.enabled = cp.vl["POWERTRAIN_DATA"]["ACC_STATUS"] != 0
     ret.cruiseState.available = bool(cp.vl[self.car_state_scm_msg]["MAIN_ON"])
 

--- a/opendbc/car/structs.py
+++ b/opendbc/car/structs.py
@@ -34,7 +34,7 @@ def auto_field():
 
 @dataclass_transform()
 def auto_dataclass(cls=None, /, **kwargs):
-  cls_annotations = cls.__dict__.get('__annotations__', {})
+  cls_annotations = cls.__annotations__
   for name, typ in cls_annotations.items():
     current_value = getattr(cls, name)
     if current_value is AUTO_OBJ:

--- a/opendbc/car/tests/routes.py
+++ b/opendbc/car/tests/routes.py
@@ -16,6 +16,7 @@ from opendbc.car.values import Platform
 from opendbc.car.volkswagen.values import CAR as VOLKSWAGEN
 from opendbc.car.body.values import CAR as COMMA
 from opendbc.car.psa.values import CAR as PSA
+from opendbc.car.volvo.values import CAR as VOLVO
 
 # FIXME: add routes for these cars
 non_tested_cars = [
@@ -369,6 +370,8 @@ routes = [
   CarTestRoute("c8a98e58647765ad/00000002--84e4746136", TESLA.TESLA_MODEL_Y),
   CarTestRoute("2c912ca5de3b1ee9/0000025d--6eb6bcbca4", TESLA.TESLA_MODEL_Y, segment=4),
   CarTestRoute("bdda168c0c35fad7/00000001--5c5a36ec06", TESLA.TESLA_MODEL_X), # openpilot longitudinal
+
+  CarTestRoute("1a659bbcb3d24b75/00000641--39552419d4", VOLVO.VOLVO_V60),
 
   # Segments that test specific issues
   # Controls mismatch due to standstill threshold

--- a/opendbc/car/tests/test_fw_fingerprint.py
+++ b/opendbc/car/tests/test_fw_fingerprint.py
@@ -262,7 +262,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         print(f'get_vin {name} case, query time={self.total_time / self.N} seconds')
 
   def test_fw_query_timing(self):
-    total_ref_time = 8.2
+    total_ref_time = 8.3
     brand_ref_times = {
       'gm': 1.0,
       'body': 0.1,
@@ -278,6 +278,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
       'volkswagen': 0.65,
       'rivian': 0.3,
       'psa': 0.1,
+      'volvo': 0.1,
     }
 
     total_times = 0.0

--- a/opendbc/car/torque_data/override.toml
+++ b/opendbc/car/torque_data/override.toml
@@ -23,6 +23,9 @@ legend = ["LAT_ACCEL_FACTOR", "MAX_LAT_ACCEL_MEASURED", "FRICTION"]
 "TESLA_MODEL_Y" = [nan, 2.5, nan]
 "TESLA_MODEL_X" = [nan, 2.5, nan]
 
+# Volvo angle based controller
+"VOLVO_V60" = [2.5, 2.5, 0.1]
+
 # Guess
 "FORD_BRONCO_SPORT_MK1" = [nan, 1.5, nan]
 "FORD_ESCAPE_MK4" = [nan, 1.5, nan]

--- a/opendbc/car/values.py
+++ b/opendbc/car/values.py
@@ -14,8 +14,9 @@ from opendbc.car.subaru.values import CAR as SUBARU
 from opendbc.car.tesla.values import CAR as TESLA
 from opendbc.car.toyota.values import CAR as TOYOTA
 from opendbc.car.volkswagen.values import CAR as VOLKSWAGEN
+from opendbc.car.volvo.values import CAR as VOLVO
 
-Platform = BODY | CHRYSLER | FORD | GM | HONDA | HYUNDAI | MAZDA | MOCK | NISSAN | PSA | RIVIAN | SUBARU | TESLA | TOYOTA | VOLKSWAGEN
+Platform = BODY | CHRYSLER | FORD | GM | HONDA | HYUNDAI | MAZDA | MOCK | NISSAN | PSA | RIVIAN | SUBARU | TESLA | TOYOTA | VOLKSWAGEN | VOLVO
 BRANDS = get_args(Platform)
 
 PLATFORMS: dict[str, Platform] = {str(platform): platform for brand in BRANDS for platform in brand}

--- a/opendbc/car/volvo/carcontroller.py
+++ b/opendbc/car/volvo/carcontroller.py
@@ -1,0 +1,165 @@
+from opendbc.can import CANPacker
+from opendbc.car import Bus, DT_CTRL
+
+try:
+  from openpilot.common.params import Params
+except ImportError:
+  Params = None
+from opendbc.car.lateral import apply_std_steer_angle_limits
+from opendbc.car.interfaces import CarControllerBase
+from opendbc.car.volvo import volvocan
+from opendbc.car.volvo.values import CarControllerParams, SteerDirection
+from opendbc.sunnypilot.car.volvo.icbm import IntelligentCruiseButtonManagementInterface
+
+
+class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterface):
+  def __init__(self, dbc_names, CP, CP_SP):
+    CarControllerBase.__init__(self, dbc_names, CP, CP_SP)
+    IntelligentCruiseButtonManagementInterface.__init__(self, CP, CP_SP)
+    self.CP = CP
+    self.CCP = CarControllerParams(CP)
+    self.packer_pt = CANPacker(dbc_names[Bus.pt])
+    self.frame = 0
+
+    self.apply_steer_prev = 0
+    self.apply_steer_dir_prev = SteerDirection.NONE
+
+    self.latActive_prev = False
+    self.steer_blocked = False
+    self.steer_blocked_cnt = 0
+    self.steer_dir_bf_block = SteerDirection.NONE
+
+    # Custom ACC increment: read once at init, refreshed every 100 frames.
+    # Passed to carstate so _pending_delta emits the right number of events.
+    self._params = Params() if Params is not None else None
+    self._custom_acc_step = max(1, int(self._params.get("CustomAccShortPressIncrement", return_default=True) or 1)) if self._params is not None else 1
+
+    # SNG
+    self.last_resume_frame = 0
+    self.distance = 0
+    self.waiting = False
+    self.sng_count = 0
+    # FSM3 ACC_Check=1 ack window: stock FSM3 has ACC_Check=0; ECU ignores
+    # OP's CCButtons resume unless FSM3 confirms it. Force 25 frames (~0.5s).
+    self.sng_ack_frames = 0
+
+    # wall-clock gate for FSM3/FSM1 TX — frame%2 unreliable due to controlsd jitter;
+    # fwd_hook blocks stock FSM3/FSM1 when controls_allowed && !gas_pressed, relay at 50Hz.
+    self.next_long_tx_nanos = 0
+    self.LONG_TX_PERIOD_NANOS = 20_000_000  # 50Hz, matching stock FSM3/FSM1
+
+  def update(self, CC, CC_SP, CS, now_nanos):
+    can_sends = []
+
+    actuators = CC.actuators
+    pcm_cancel_cmd = CC.cruiseControl.cancel
+
+    # TODO: verify if this minSteerSpeed guard is still needed
+    if pcm_cancel_cmd and CS.out.vEgo > self.CP.minSteerSpeed:
+      can_sends.append(volvocan.create_button_msg(self.packer_pt, cancel=True))
+
+    # run at 50hz
+    if self.frame % 2 == 0:
+      if CC.latActive and CS.out.vEgo > self.CP.minSteerSpeed:
+        apply_steer = apply_std_steer_angle_limits(
+          actuators.steeringAngleDeg, self.apply_steer_prev, CS.out.vEgoRaw,
+          CS.out.steeringAngleDeg, CC.latActive, CarControllerParams.ANGLE_LIMITS
+        )
+        apply_steer_dir = SteerDirection.LEFT if apply_steer > 0 else SteerDirection.RIGHT
+
+        error = CS.out.steeringAngleDeg - apply_steer
+        error_with_deadzone = 0 if abs(error) < CarControllerParams.DEADZONE else error
+
+        # Update prev with desired if just enabled.
+        if not self.latActive_prev:
+          self.apply_steer_dir_prev = apply_steer_dir
+
+        if self.steer_blocked:
+          if (apply_steer_dir == self.steer_dir_bf_block) or (self.steer_blocked_cnt <= 0) or (error_with_deadzone == 0):
+            self.steer_blocked = False
+        else:
+          if apply_steer_dir != self.apply_steer_dir_prev and error_with_deadzone != 0:
+            self.steer_blocked = True
+            self.steer_blocked_cnt = CarControllerParams.BLOCK_LEN
+            self.steer_dir_bf_block = self.apply_steer_dir_prev
+
+        if self.steer_blocked:
+          self.steer_blocked_cnt -= 1
+          apply_steer_dir = SteerDirection.NONE
+        elif error_with_deadzone == 0:
+          # Set old request when inside deadzone
+          apply_steer_dir = self.apply_steer_dir_prev
+
+      else:
+        apply_steer = 0
+        apply_steer_dir = SteerDirection.NONE
+
+      can_sends.append(volvocan.create_lka_msg(self.packer_pt, apply_steer, int(apply_steer_dir)))
+
+      self.apply_steer_prev = apply_steer
+      self.apply_steer_dir_prev = apply_steer_dir
+      self.latActive_prev = CC.latActive
+
+      # Manipulate data from servo to FSM
+      # Avoids faults that will stop servo from accepting steering commands.
+      can_sends.append(volvocan.create_lkas_state_msg(self.packer_pt, CS.out.steeringAngleDeg, CS.pscm_stock_values))
+
+    at_standstill = (CS.out.cruiseState.enabled and CS.out.cruiseState.standstill
+                     and CS.out.vEgo < 0.01)
+
+    # SNG
+    if (self.frame - self.last_resume_frame) * DT_CTRL > 1.00:
+      if at_standstill and not self.waiting:
+        self.distance = CS.acc_distance
+        self.waiting = True
+        self.sng_count = 0
+
+      lead_moved = CS.acc_distance > self.distance
+
+      if at_standstill and self.waiting and lead_moved:
+        can_sends.extend([volvocan.create_button_msg(self.packer_pt, resume=True)] * self.CCP.BUTTON_BURST)
+        if self.sng_count == 0:
+          self.sng_ack_frames = 25
+        self.sng_count += 1
+      # disable sending resume after 5 cycles sent or if no more in standstill
+      if self.waiting and (self.sng_count >= 5 or not CS.out.cruiseState.standstill):
+        self.waiting = False
+        self.last_resume_frame = self.frame
+
+    # FSM3/FSM1 at 50Hz wall-clock: relay stock values so ECU doesn't fault.
+    # Override ACC_Check=1 during SNG resume so ECU acknowledges OP's CCButtons resume.
+    long_tx_due = now_nanos >= self.next_long_tx_nanos
+    if long_tx_due:
+      next_tx = self.next_long_tx_nanos + self.LONG_TX_PERIOD_NANOS
+      if self.next_long_tx_nanos == 0 or next_tx <= now_nanos:
+        next_tx = now_nanos + self.LONG_TX_PERIOD_NANOS
+      self.next_long_tx_nanos = next_tx
+
+      accel = float(CS.stock_FSM3["ACC_AccelerationRequest"])
+      if self.sng_ack_frames > 0:
+        acc_check = 1
+        self.sng_ack_frames -= 1
+      else:
+        acc_check = int(CS.stock_FSM3["ACC_Check"])
+
+      can_sends.append(volvocan.create_radar(self.packer_pt, CS.stock_FSM1, False))
+      can_sends.append(volvocan.create_longitudinal(self.packer_pt, CS.stock_FSM3, accel, acc_check))
+
+    # Refresh custom ACC step every 100 frames and forward to carstate so that
+    # _pending_delta emits exactly one synthetic event per physical ACC step.
+    if self.frame % 100 == 0 and self._params is not None:
+      self._custom_acc_step = max(1, int(self._params.get("CustomAccShortPressIncrement", return_default=True) or 1))
+    CS._custom_acc_step = self._custom_acc_step
+
+    # Intelligent Cruise Button Management
+    icbm_sends = IntelligentCruiseButtonManagementInterface.update(self, CC_SP, CS, self.packer_pt, self.frame, self.last_button_frame)
+    if icbm_sends:
+      CS._pending_delta = 0
+      CS._icbm_suppress_frames = 25
+    can_sends.extend(icbm_sends)
+
+    new_actuators = actuators.as_builder()
+    new_actuators.steeringAngleDeg = self.apply_steer_prev
+
+    self.frame += 1
+    return new_actuators, can_sends

--- a/opendbc/car/volvo/carcontroller.py
+++ b/opendbc/car/volvo/carcontroller.py
@@ -55,7 +55,7 @@ class CarController(CarControllerBase, IntelligentCruiseButtonManagementInterfac
     pcm_cancel_cmd = CC.cruiseControl.cancel
 
     # TODO: verify if this minSteerSpeed guard is still needed
-    if pcm_cancel_cmd and CS.out.vEgo > self.CP.minSteerSpeed:
+    if pcm_cancel_cmd and CS.out.vEgo > self.CP.minSteerSpeed and not CS.out.brakePressed:
       can_sends.append(volvocan.create_button_msg(self.packer_pt, cancel=True))
 
     # run at 50hz

--- a/opendbc/car/volvo/carstate.py
+++ b/opendbc/car/volvo/carstate.py
@@ -1,0 +1,148 @@
+import copy
+from opendbc.can import CANParser
+from opendbc.car.common.conversions import Conversions as CV
+from opendbc.car.interfaces import CarStateBase
+from opendbc.car.volvo.values import CarControllerParams, DBC, CANBUS
+from opendbc.car import Bus, structs
+
+ButtonType = structs.CarState.ButtonEvent.Type
+
+
+class CarState(CarStateBase):
+  def __init__(self, CP, CP_SP):
+    super().__init__(CP, CP_SP)
+    self.cruiseState_enabled_prev = False
+    self.eps_torque_timer = 0
+    self.frame = 0
+    self._cruise_speed_prev_kph = 0
+    self._pending_delta = 0
+    self._icbm_suppress_frames = 0
+    self._custom_acc_step = 1  # set by carcontroller each frame; default 1 km/h
+
+  def update(self, can_parsers) -> structs.CarState:
+    pt_cp = can_parsers[Bus.pt]
+    cam_cp = can_parsers[Bus.cam]
+
+    ret = structs.CarState()
+    ret_sp = structs.CarStateSP()
+
+    # car speed
+    ret.vEgoRaw = pt_cp.vl["VehicleSpeed1"]["VehicleSpeed"] * CV.KPH_TO_MS
+    ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
+    ret.standstill = ret.vEgoRaw < 0.1
+
+    # gas pedal
+    ret.gasPressed = pt_cp.vl["AccPedal"]["AccPedal"] >= 10
+
+    # brake pedal
+    ret.brakePressed = pt_cp.vl["Brake_Info"]["BrakePedal"] == 2
+
+    # steering
+    ret.steeringAngleDeg = pt_cp.vl["PSCM1"]["SteeringAngleServo"]
+    ret.steeringRateDeg = pt_cp.vl["SAS0"]["SteeringRateOfChange"]
+    self.steeringDirection = pt_cp.vl["SAS0"]["SteeringDirection"]
+    ret.steeringTorque = pt_cp.vl["PSCM1"]["EPSTorque"]
+    if self.steeringDirection:
+      ret.steeringTorque = -abs(ret.steeringTorque)
+    ret.steeringTorqueEps = pt_cp.vl["PSCM1"]["LKATorque"]
+    ret.steeringPressed = abs(ret.steeringTorque) > 50
+
+    # cruise state
+    ret.cruiseState.speed = pt_cp.vl["ACC_Speed"]["ACC_Speed"] * CV.KPH_TO_MS
+    ret.cruiseState.speedCluster = ret.cruiseState.speed
+    ret.cruiseState.available = bool(cam_cp.vl["FSM0"]["ACC_Available"])
+    ret.cruiseState.enabled = bool(cam_cp.vl["FSM0"]["ACC_Enabled"])
+    # standstill hold; SNG uses this to time the resume blast (hard-cancel without it, drive 38)
+    ret.cruiseState.standstill = bool(cam_cp.vl["FSM3"]["ACC_Standstill"])
+    ret.cruiseState.nonAdaptive = False
+    ret.accFaulted = False
+    self.acc_distance = cam_cp.vl["FSM1"]["ACC_Distance"]
+
+    # Check if servo stops responding when ACC is active
+    if ret.cruiseState.enabled and ret.vEgo > self.CP.minSteerSpeed:
+      if not self.cruiseState_enabled_prev:
+        self.eps_torque_timer = 0
+
+      if ret.steeringTorqueEps == 0:
+        self.eps_torque_timer += 1
+      else:
+        self.eps_torque_timer = 0
+
+      ret.steerFaultTemporary = self.eps_torque_timer >= CarControllerParams.STEER_TIMEOUT
+    else:
+      ret.steerFaultTemporary = False
+
+    self.cruiseState_enabled_prev = ret.cruiseState.enabled
+
+    # gear
+    ret.gearShifter = structs.CarState.GearShifter.drive
+
+    # safety
+    ret.stockFcw = False
+    ret.stockAeb = False
+
+    # button presses
+    ret.leftBlinker = pt_cp.vl["MiscCarInfo"]["TurnSignal"] == 1
+    ret.rightBlinker = pt_cp.vl["MiscCarInfo"]["TurnSignal"] == 3
+
+    # Synthesize one accelCruise/decelCruise per frame from pending delta.
+    # Suppressed after ICBM sends a button to avoid feedback into v_cruise_kph.
+    cruise_kph_now = round(ret.cruiseState.speed * CV.MS_TO_KPH)
+    if self._icbm_suppress_frames > 0:
+      self._cruise_speed_prev_kph = cruise_kph_now
+      self._icbm_suppress_frames -= 1
+    elif ret.cruiseState.enabled and self.cruiseState_enabled_prev:
+      self._pending_delta += cruise_kph_now - self._cruise_speed_prev_kph
+    self._cruise_speed_prev_kph = cruise_kph_now
+
+    # Emit one event per physical ACC step; trigger on delta >= 1 to handle Volvo's
+    # sub-step snaps (e.g. 41→45 km/h) that would never reach a larger threshold.
+    step = max(1, self._custom_acc_step)
+    if self._pending_delta >= 1:
+      ret.buttonEvents = [structs.CarState.ButtonEvent(pressed=False, type=ButtonType.accelCruise)]
+      self._pending_delta = max(0, self._pending_delta - step)
+    elif self._pending_delta <= -1:
+      ret.buttonEvents = [structs.CarState.ButtonEvent(pressed=False, type=ButtonType.decelCruise)]
+      self._pending_delta = min(0, self._pending_delta + step)
+
+    # lock info
+    ret.doorOpen = not all([pt_cp.vl["Doors"]["DriverDoorClosed"], pt_cp.vl["Doors"]["PassengerDoorClosed"]])
+    ret.seatbeltUnlatched = False
+
+    self.pscm_stock_values = pt_cp.vl["PSCM1"]
+    self.stock_FSM1 = copy.copy(cam_cp.vl["FSM1"])
+    self.stock_FSM3 = copy.copy(cam_cp.vl["FSM3"])
+    self.ACC_Check = cam_cp.vl["FSM3"]["ACC_Check"]
+
+    # TSR speed limit from camera (0 = no sign)
+    tsr_raw = cam_cp.vl["FSM5"]["TSR_Speed"]
+    ret_sp.speedLimit = tsr_raw * CV.KPH_TO_MS if tsr_raw > 0 else 0.0
+
+    self.frame += 1
+    return ret, ret_sp
+
+  @staticmethod
+  def get_can_parsers(CP, CP_SP):
+    pt_messages = [
+      ("VehicleSpeed1", 50),
+      ("AccPedal", 100),
+      ("BrakePedal", 50),
+      ("Brake_Info", 50),
+      ("PSCM1", 50),
+      ("ACC_Speed", 50),
+      ("MiscCarInfo", 25),
+      ("Doors", 20),
+      ("SAS0", 100)
+    ]
+
+    cam_messages = [
+      ("FSM0", 100),
+      ("FSM1", 50),
+      ("FSM3", 50),
+      ("FSM5", 10),
+    ]
+
+    return {
+      Bus.pt: CANParser(DBC[CP.carFingerprint][Bus.pt], pt_messages, CANBUS.pt),
+      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], cam_messages, CANBUS.cam),
+    }

--- a/opendbc/car/volvo/fingerprints.py
+++ b/opendbc/car/volvo/fingerprints.py
@@ -1,0 +1,26 @@
+from opendbc.car.structs import CarParams
+from opendbc.car.volvo.values import CAR
+
+Ecu = CarParams.Ecu
+
+FINGERPRINTS = {
+  CAR.VOLVO_V60: [
+    {
+      16: 8, 32: 8, 81: 8, 99: 8, 104: 8, 112: 8,
+      277: 8, 307: 8, 320: 8, 328: 8, 336: 8, 343: 8,
+      352: 8, 359: 8, 384: 8, 465: 8, 511: 8, 522: 8,
+      544: 8, 565: 8, 582: 8, 608: 8, 609: 8, 610: 8,
+      624: 8, 648: 8, 665: 8, 673: 8, 704: 8, 706: 8,
+      750: 8, 751: 8, 788: 8, 797: 8, 802: 8, 807: 8,
+      821: 8, 978: 8,
+    },
+  ],
+}
+
+FW_VERSIONS = {
+  CAR.VOLVO_V60: {
+    (Ecu.engine, 0x7e0, None): [
+      b'31361041 AJ\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+    ],
+  }
+}

--- a/opendbc/car/volvo/interface.py
+++ b/opendbc/car/volvo/interface.py
@@ -1,0 +1,43 @@
+from opendbc.car import Bus, get_safety_config, structs
+from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.volvo.carcontroller import CarController
+from opendbc.car.volvo.carstate import CarState
+from opendbc.car.volvo.radar_interface import RadarInterface
+from opendbc.car.volvo.values import DBC
+
+#ButtonType = car.CarState.ButtonEvent.Type
+#EventName = car.CarEvent.EventName
+
+class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+  # Without this binding, CarInterfaceBase uses the default RadarInterfaceBase stub
+  # which returns empty RadarData — liveTracks.points would stay at 0.
+  RadarInterface = RadarInterface
+
+  @staticmethod
+  #def _get_params(ret, candidate: CAR, fingerprint, car_fw, experimental_long, docs):
+  def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, alpha_long, is_release, docs) -> structs.CarParams:
+    ret.brand = "volvo"
+
+    ret.safetyConfigs = [get_safety_config(structs.CarParams.SafetyModel.volvo)]
+    # ret.dashcamOnly = True
+
+    # When Bus.radar is in DBC, RadarInterface decodes the Delphi ESR 2.5 directly
+    # (64 tracks at 20Hz) instead of relying on stock FSM's single-lead ACC_Distance.
+    ret.radarUnavailable = Bus.radar not in DBC[candidate]
+
+    ret.steerControlType = structs.CarParams.SteerControlType.angle
+
+    ret.steerActuatorDelay = 0.2
+    ret.steerLimitTimer = 0.8
+
+    ret.openpilotLongitudinalControl = False
+
+    return ret
+
+  @staticmethod
+  def _get_params_sp(stock_cp: structs.CarParams, ret: structs.CarParamsSP, candidate, fingerprint: dict[int, dict[int, int]],
+ car_fw: list[structs.CarParams.CarFw], alpha_long: bool, is_release_sp: bool, docs: bool) -> structs.CarParamsSP:
+    ret.intelligentCruiseButtonManagementAvailable = True
+    return ret

--- a/opendbc/car/volvo/radar_interface.py
+++ b/opendbc/car/volvo/radar_interface.py
@@ -1,0 +1,85 @@
+from math import cos, sin
+from opendbc.can import CANParser
+from opendbc.car import Bus, structs
+from opendbc.car.common.conversions import Conversions as CV
+from opendbc.car.interfaces import RadarInterfaceBase
+from opendbc.car.volvo.values import CANBUS, DBC
+
+# Delphi ESR 2.5: 64 track slots at 0x500..0x53F, 20Hz, on CANBUS.body (bus 1).
+# The comma harness taps the FLR→FSM private CAN, exposing the raw stream to OP.
+DELPHI_ESR_TRACK_ADDRS = list(range(0x500, 0x540))  # Target1..Target64
+DELPHI_ESR_TRACK_NAMES = [f"Target{i}" for i in range(1, 65)]
+# Pair (addr, name) so we can key state by address (what CANParser reports in
+# its update-returns-set) and still read signals by message name via vl[name].
+TRACK_ADDR_NAMES = list(zip(DELPHI_ESR_TRACK_ADDRS, DELPHI_ESR_TRACK_NAMES, strict=True))
+TRIGGER_MSG_ADDR = DELPHI_ESR_TRACK_ADDRS[-1]
+
+# ESR CAN_TX_TRACK_STATUS codes. 0 = no target. 6 = invalid coasted.
+# Everything else represents a real or recently-real track.
+INVALID_STATUSES = {0, 6}
+
+# A track needs this many consecutive valid frames before we surface it to the
+# planner. Suppresses one-off ghosts without adding meaningful latency (20Hz).
+MIN_VALID_CNT = 3
+
+
+def _create_radar_can_parser(CP) -> CANParser:
+  messages = [(name, 20) for name in DELPHI_ESR_TRACK_NAMES]
+  return CANParser(DBC[CP.carFingerprint][Bus.radar], messages, CANBUS.body)
+
+
+class RadarInterface(RadarInterfaceBase):
+  def __init__(self, CP, CP_SP):
+    super().__init__(CP, CP_SP)
+    self.updated_messages: set[int] = set()
+    self.valid_cnt: dict[int, int] = {addr: 0 for addr in DELPHI_ESR_TRACK_ADDRS}
+    self.track_id = 0
+    self.rcp = None if CP.radarUnavailable else _create_radar_can_parser(CP)
+
+  def update(self, can_strings):
+    if self.rcp is None:
+      return super().update(None)
+
+    self.updated_messages.update(self.rcp.update(can_strings))
+
+    # ESR sends all 64 slots every 50ms. Wait for the last slot before publishing
+    # so consumers see a full sweep rather than partial updates.
+    if TRIGGER_MSG_ADDR not in self.updated_messages:
+      return None
+    self.updated_messages.clear()
+
+    ret = structs.RadarData()
+    if not self.rcp.can_valid:
+      ret.errors.canError = True
+
+    for addr, name in TRACK_ADDR_NAMES:
+      cpt = self.rcp.vl[name]
+      rng = cpt["CAN_TX_TRACK_RANGE"]
+      status = int(cpt["CAN_TX_TRACK_STATUS"])
+      valid = status not in INVALID_STATUSES and rng > 0.5
+
+      if valid:
+        self.valid_cnt[addr] = min(self.valid_cnt[addr] + 1, MIN_VALID_CNT + 2)
+      else:
+        self.valid_cnt[addr] = max(self.valid_cnt[addr] - 1, 0)
+
+      # Only write track data when valid; keep last good reading on flicker to avoid
+      # garbage points (dRel=0, vRel saturates to ±81.91) leaking to the planner.
+      if valid and self.valid_cnt[addr] >= MIN_VALID_CNT:
+        if addr not in self.pts:
+          self.pts[addr] = structs.RadarData.RadarPoint()
+          self.pts[addr].trackId = self.track_id
+          self.track_id += 1
+        angle_rad = cpt["CAN_TX_TRACK_ANGLE"] * CV.DEG_TO_RAD
+        # ESR angle positive = target right of boresight; flip sin() for left-positive yRel.
+        self.pts[addr].dRel = rng * cos(angle_rad)
+        self.pts[addr].yRel = -rng * sin(angle_rad)
+        self.pts[addr].vRel = cpt["CAN_TX_TRACK_RANGE_RATE"]
+        self.pts[addr].aRel = cpt["CAN_TX_TRACK_RANGE_ACCEL"]
+        self.pts[addr].yvRel = float("nan")
+        self.pts[addr].measured = True
+      elif self.valid_cnt[addr] < MIN_VALID_CNT and addr in self.pts:
+        del self.pts[addr]
+
+    ret.points = list(self.pts.values())
+    return ret

--- a/opendbc/car/volvo/values.py
+++ b/opendbc/car/volvo/values.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass, field
+from enum import IntEnum
+
+from opendbc.car import Bus, CarSpecs, DbcDict, PlatformConfig, Platforms, uds, DT_CTRL
+from opendbc.car.lateral import AngleSteeringLimits
+from opendbc.car.docs_definitions import CarHarness, CarDocs, CarParts
+from opendbc.car.fw_query_definitions import FwQueryConfig, Request, p16
+from opendbc.car.structs import CarParams
+
+Ecu = CarParams.Ecu
+
+# Volvo EUCD/C1MCA CAN buses: pt (BCM/FSM/PSCM/SAS), chassis (DIM/PAM via CEM), ext (SODL/SODR via CEM)
+
+
+class SteerDirection(IntEnum):
+  """LKASteerDirection: EUCD needs 8-frame wait on direction change; C1MCA can use BOTH."""
+  NONE = 0
+  RIGHT = 1
+  LEFT = 2
+  BOTH = 3
+
+
+class CarControllerParams:
+  ANGLE_LIMITS: AngleSteeringLimits = AngleSteeringLimits(90,
+    ([0., 5., 15.], [5., .8, .15]),
+    ([0., 5., 15.], [5., 3.5, 0.4]),
+  )
+
+  STEER_TIMEOUT = 30 / DT_CTRL  # frames before steer fault on sustained 0-torque from EPS
+  BLOCK_LEN = 8   # EUCD: frames to block steering on direction change (servo ignores otherwise)
+  DEADZONE = 0.2  # deg: hold previous direction inside deadzone to avoid unwind
+  BUTTON_BURST = 15  # CAN messages per button press to increase ECU acceptance probability
+
+  ACCEL_MIN = -4.0  # m/s^2
+  ACCEL_MAX = 2.0   # m/s^2
+
+  def __init__(self, CP):
+    pass
+
+class CANBUS:
+  pt = 0
+  body = 1  # aux bus — carries Delphi ESR 2.5 radar (0x500..0x53F) and CEM dynamics
+  cam = 2
+
+
+# Delphi ESR 2.5 on aux bus (0x500–0x53F, 20Hz, 64 tracks); read directly so planner sees leads independently of stock FSM
+RADAR_ESR = "ESR"
+
+@dataclass
+class VolvoEUCDPlatformConfig(PlatformConfig):
+  dbc_dict: DbcDict = field(default_factory=lambda: {
+    Bus.pt: 'volvo_v60_2015_pt',
+    Bus.radar: RADAR_ESR,
+  })
+
+
+@dataclass
+class VolvoCarDocs(CarDocs):
+  package: str = "Adaptive Cruise Control & Lane Keeping Aid"
+  car_parts: CarParts = field(default_factory=CarParts.common([CarHarness.custom]))
+
+
+@dataclass(frozen=True)
+class VolvoCarSpecs(CarSpecs):
+  steerRatio: float = 15.0
+  centerToFrontRatio: float = 0.44
+  minSteerSpeed: float = 1.0
+
+
+class CAR(Platforms):
+  VOLVO_V60 = VolvoEUCDPlatformConfig(
+    [VolvoCarDocs("Volvo V60 2010-18")],
+    VolvoCarSpecs(mass=1750, wheelbase=2.776),
+  )
+
+
+VOLVO_VERSION_REQUEST = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
+  p16(0xf1a2)
+VOLVO_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40]) + \
+  p16(0xf1a2)
+
+FW_QUERY_CONFIG = FwQueryConfig(
+  requests=[
+    Request(
+      [VOLVO_VERSION_REQUEST],
+      [VOLVO_VERSION_RESPONSE],
+      bus=0,
+    ),
+  ],
+)
+
+DBC = CAR.create_dbc_map()

--- a/opendbc/car/volvo/volvocan.py
+++ b/opendbc/car/volvo/volvocan.py
@@ -1,0 +1,91 @@
+def create_button_msg(packer, resume=False, cancel=False, set_plus=False, minus=False, bus=0):
+  # TODO: validate
+  msg = {
+    "ACCOnOffBtn": cancel,
+    "ACCOnOffBtnInv": not cancel,
+    "ACCResumeBtn": resume,
+    "ACCResumeBtnInv": not resume,
+    "ACCSetBtn": set_plus,
+    "ACCSetBtnInv": not set_plus,
+    "ACCMinusBtn": minus,
+    "ACCMinusBtnInv": not minus,
+  }
+  return packer.make_can_msg("CCButtons", bus, msg)
+
+
+def create_lkas_state_msg(packer, steering_angle: float, stock_values: dict):
+  # zero LKATorque/LKAActive to prevent stock LKA interference
+  msg = {
+    "LKATorque": 0,
+    "SteeringAngleServo": steering_angle,
+    "byte0": stock_values["byte0"],
+    "byte4": stock_values["byte4"],
+    "byte7": stock_values["byte7"],
+    "LKAActive": int(stock_values["LKAActive"]) & 0xF5,
+    "EPSTorque": stock_values["EPSTorque"],
+  }
+  return packer.make_can_msg("PSCM1", 2, msg)
+
+
+def calculate_lka_checksum(dat: bytearray) -> int:
+  steer_angle_request = ((dat[3] & 0x3F) << 8) + dat[4]
+  steering_direction_request = dat[5] & 0x03
+  trqlim = dat[2]
+
+  s = (trqlim + steering_direction_request + steer_angle_request + (steer_angle_request >> 8)) & 0xFF
+  return s ^ 0xFF
+
+
+def create_lka_msg(packer, apply_steer: float, steer_direction: int):
+  values = {
+    "LKAAngleReq": apply_steer,
+    "LKASteerDirection": steer_direction,
+    "TrqLim": 0,
+
+    "SET_X_22": 0x25,
+    "SET_X_02": 0,
+    "SET_X_10": 0x10,
+    "SET_X_A4": 0xa7,
+  }
+
+  # calculate checksum
+  dat = packer.make_can_msg("FSM2", 0, values)[1]
+  values["Checksum"] = calculate_lka_checksum(dat)
+
+  return packer.make_can_msg("FSM2", 0, values)
+
+
+def create_longitudinal(packer, stock_fsm3, accel, acc_check):
+  # pass stock FSM3 verbatim except ACC_AccelerationRequest and ACC_Check; bit flip faults ECU (drive 27)
+  values = {s: stock_fsm3[s] for s in (
+    "ACC_Standstill",
+    "Byte_01",
+    "Byte_02",
+    "Byte_2",
+    "Byte_3",
+    "Byte_4",
+    "Byte_5",
+    "Byte_6",
+    "Byte_7",
+  )}
+  values |= {
+    "ACC_AccelerationRequest": accel,
+    "ACC_Check": acc_check,
+  }
+  return packer.make_can_msg("FSM3", 0, values)
+
+
+def create_radar(packer, stock_fsm1, long_active):
+  # pass stock FSM1 verbatim; spoofing ACC_Distance=255 caused stock ACC to disengage below 30 km/h
+  _ = long_active  # kept for signature stability
+  values = {s: stock_fsm1[s] for s in (
+    "ACC_Distance",
+    "Byte_1",
+    "Byte_2",
+    "Byte_3",
+    "Byte_4",
+    "Byte_5",
+    "Byte_6",
+    "Byte_7",
+  )}
+  return packer.make_can_msg("FSM1", 0, values)

--- a/opendbc/dbc/volvo_v60_2015_pt.dbc
+++ b/opendbc/dbc/volvo_v60_2015_pt.dbc
@@ -44,10 +44,13 @@ BO_ 16 SAS0: 8 SAS
  SG_ SteeringAngle : 53|14@0+ (0.0445,0) [0|65535] "degrees" XXX
 
 BO_ 32 AccPedal: 8 XXX
- SG_ AccPedal : 17|10@0+ (0.1,0) [0|100.0] "%" XXX
+ SG_ AccPedal : 17|10@0+ (0.1,0) [0|102.3] "%" XXX
 
 BO_ 81 FSM0: 8 FSM
- SG_ ACCStatus : 18|3@0+ (1,0) [0|7] "" XXX
+ SG_ ACC_FrontCar : 16|1@0+ (1,0) [0|1] "" XXX
+ SG_ ACC_Available : 17|1@0+ (1,0) [0|7] "" XXX
+ SG_ ACC_Enabled : 18|1@0+ (1,0) [0|1] "" XXX
+ SG_ ACC_BrakeAlert : 27|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 277 NEW_MSG_7: 8 XXX
  SG_ NEW_SIGNAL_1 : 39|16@0+ (1,0) [0|65535] "" XXX
@@ -125,8 +128,8 @@ BO_ 565 wheelspeed0: 8 BCM
 
 BO_ 582 PSCM1: 8 PSCM
  SG_ byte0 : 7|8@0+ (1,0) [0|255] "" XXX
- SG_ SteeringWheelRateOfChange : 15|8@0+ (1,0) [0|255] "" XXX
- SG_ SteeringAngleServo : 23|16@0+ (0.0447,-1464.8) [0|65535] "deg" XXX
+ SG_ EPSTorque : 15|8@0+ (1,0) [0|255] "" XXX
+ SG_ SteeringAngleServo : 23|16@0+ (0.0447,-1465) [0|65535] "deg" XXX
  SG_ LKATorque : 35|12@0+ (1,-2000) [0|65535] "" XXX
  SG_ byte4 : 39|4@0+ (1,0) [0|15] "" XXX
  SG_ LKAActive : 55|8@0+ (1,0) [0|255] "" XXX
@@ -134,6 +137,13 @@ BO_ 582 PSCM1: 8 PSCM
 
 BO_ 608 FSM1: 8 FSM
  SG_ ACC_Distance : 7|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_1 : 15|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_2 : 23|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_3 : 31|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_4 : 39|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_5 : 47|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_6 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_7 : 63|8@0+ (1,0) [0|255] "" XXX
 
 BO_ 609 fromWhere: 8 XXX
  SG_ COUNTER : 3|4@0+ (1,0) [0|15] "" XXX
@@ -155,10 +165,16 @@ BO_ 612 Accessories_03: 8 XXX
 
 BO_ 624 FSM3: 8 FSM
  SG_ ACC_Standstill : 0|1@0+ (1,0) [0|1] "" XXX
+ SG_ Byte_02 : 1|1@0+ (1,0) [0|1] "" XXX
  SG_ ACC_Check : 2|1@0+ (1,0) [0|1] "" XXX
- SG_ ACC_AccelDecel : 15|8@0+ (1,0) [0|255] "" XXX
- SG_ ACC_Some : 17|10@0+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 47|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_01 : 7|5@0+ (1,0) [0|31] "" XXX
+ SG_ ACC_AccelerationRequest : 15|8@0+ (0.04,-5.04) [0|255] "" XXX
+ SG_ Byte_2 : 23|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_3 : 31|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_4 : 39|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_5 : 47|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_6 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ Byte_7 : 63|8@0+ (1,0) [0|255] "" XXX
 
 BO_ 648 BrakePedal: 8 XXX
  SG_ Counter : 0|3@1+ (1,0) [0|6] "" XXX
@@ -266,7 +282,7 @@ BO_ 2015 diagGlobalReq: 8 XXX
 
 CM_ SG_ 16 SteeringDirection "0 = CCW, 1=CW (turning left or right of center)";
 CM_ SG_ 16 SteeringRateOfChange "Rate of change? Torque?";
-CM_ SG_ 81 ACCStatus "0=Acc Unavailable, 1=???, 2=Acc Ready, 3,4=???, 6= Acc Active, 7=Acc active tracking object (probably)";
+CM_ SG_ 81 ACC_Available "0=Acc Unavailable, 1=???, 2=Acc Ready, 3,4=???, 6= Acc Active, 7=Acc active tracking object (probably)";
 CM_ SG_ 295 ACCMinusBtnInv "Active zero when button pressed.";
 CM_ SG_ 295 TimeGapIncreaseBtnInv "Active zero when button pressed.";
 CM_ SG_ 295 TimeGapDecreaseBtnInv "Active zero when button pressed.";
@@ -283,15 +299,13 @@ CM_ SG_ 298 NEW_SIGNAL_4 "related to gas pedal";
 CM_ SG_ 298 NEW_SIGNAL_5 "related to ACCStatus";
 CM_ SG_ 298 NEW_SIGNAL_6 "went high at same time as ACCStatus >= 2";
 CM_ SG_ 298 BrakePressed "driver";
-CM_ SG_ 298 EngineRpm "Might be engine rpm. But behaves a bit weird.";
+CM_ SG_ 298 EngineRpm "Might be engine rpm. But behaves abit weird.";
 CM_ SG_ 582 byte0 "0=CCW, 1=CW, bit 2,";
-CM_ SG_ 582 SteeringWheelRateOfChange "Some rate of change for steering wheel? Torque?";
+CM_ SG_ 582 EPSTorque "Some rate of change for steering wheel? Torque?";
 CM_ SG_ 582 byte4 "High nibble";
 CM_ SG_ 582 LKAActive "Bit 1, 1 When LKA Active, Bit 3, 1 When denying?";
 CM_ SG_ 608 ACC_Distance "Seems to track distance, or speed of vehicle in front.";
 CM_ SG_ 610 SET_X_22 "0x20 Heartbeat, VEgo <58kph = 0x03, VEgo >65kph = 0x04, 0x05";
-CM_ SG_ 624 ACC_AccelDecel "Might be some acc speed, moved a bit after activating acc";
-CM_ SG_ 624 ACC_Some "Jumps to life after activating ACC, 0 when not active";
 CM_ SG_ 648 Counter "counts 0 to 6";
 CM_ SG_ 1021 TSR_Speed "Traffic Sign Recognition speed";
 CM_ SG_ 1039 TurnSignal "0 = Nothing, 1= Left, 3=Right";

--- a/opendbc/safety/declarations.h
+++ b/opendbc/safety/declarations.h
@@ -34,6 +34,7 @@
 #define SAFETY_PSA 31U
 #define SAFETY_RIVIAN 33U
 #define SAFETY_VOLKSWAGEN_MEB 34U
+#define SAFETY_VOLVO 35U
 
 #define GET_BIT(msg, b) ((bool)!!(((msg)->data[((b) / 8U)] >> ((b) % 8U)) & 0x1U))
 #define GET_FLAG(value, mask) (((value) & (mask)) == (mask))
@@ -347,3 +348,4 @@ extern const safety_hooks volkswagen_mqb_hooks;
 extern const safety_hooks volkswagen_pq_hooks;
 extern const safety_hooks rivian_hooks;
 extern const safety_hooks psa_hooks;
+extern const safety_hooks volvo_hooks;

--- a/opendbc/safety/declarations.h
+++ b/opendbc/safety/declarations.h
@@ -176,6 +176,7 @@ typedef struct {
   const bool ignore_counter;         // counter check is not performed when set to true
   const uint8_t max_counter;         // maximum value of the counter. 0 means that the counter check is skipped
   const bool ignore_quality_flag;    // true if quality flag check is skipped
+  const bool ignore_frequency_check; // true if minimum frequency enforcement is skipped
 } CanMsgCheck;
 
 typedef struct {

--- a/opendbc/safety/modes/chrysler.h
+++ b/opendbc/safety/modes/chrysler.h
@@ -173,7 +173,7 @@ static safety_config chrysler_init(uint16_t param) {
     {.msg = {{CHRYSLER_RAM_DT_ESP_8, 0, 8, 50U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},
     {.msg = {{CHRYSLER_RAM_DT_ECM_5, 0, 8, 50U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},
     {.msg = {{CHRYSLER_RAM_DT_DAS_3, 2, 8, 50U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},
-    {.msg = {{CHRYSLER_RAM_DT_Center_Stack_2, 0, 8, 1U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},
+    {.msg = {{CHRYSLER_RAM_DT_Center_Stack_2, 0, 8, 1U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true, .ignore_frequency_check = true}, { 0 }, { 0 }}},
   };
 
   static RxCheck chrysler_rx_checks[] = {
@@ -182,7 +182,7 @@ static safety_config chrysler_init(uint16_t param) {
     {.msg = {{514, 0, 8, 100U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},
     {.msg = {{CHRYSLER_ECM_5, 0, 8, 50U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},
     {.msg = {{CHRYSLER_DAS_3, 0, 8, 50U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},
-    {.msg = {{CHRYSLER_TRACTION_BUTTON, 0, 8, 1U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},
+    {.msg = {{CHRYSLER_TRACTION_BUTTON, 0, 8, 1U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true, .ignore_frequency_check = true}, { 0 }, { 0 }}},
   };
 
   static const CanMsg CHRYSLER_TX_MSGS[] = {
@@ -205,7 +205,7 @@ static safety_config chrysler_init(uint16_t param) {
     {.msg = {{CHRYSLER_RAM_HD_ESP_8, 0, 8, 50U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},
     {.msg = {{CHRYSLER_RAM_HD_ECM_5, 0, 8, 50U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},
     {.msg = {{CHRYSLER_RAM_HD_DAS_3, 2, 8, 50U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},
-    {.msg = {{CHRYSLER_RAM_HD_Center_Stack_2, 0, 8, 1U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},
+    {.msg = {{CHRYSLER_RAM_HD_Center_Stack_2, 0, 8, 1U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true, .ignore_frequency_check = true}, { 0 }, { 0 }}},
   };
 
   static const CanMsg CHRYSLER_RAM_HD_TX_MSGS[] = {

--- a/opendbc/safety/modes/tesla.h
+++ b/opendbc/safety/modes/tesla.h
@@ -14,7 +14,7 @@
   {.msg = {{0x311, 0, 7, 10U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},   /* UI_warning (blinkers, buckle switch & doors) */ \
 
 #define TESLA_VEHICLE_BUS_ADDR_CHECK \
-  {.msg = {{0x3DF, 1, 8, 2U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true}, { 0 }, { 0 }}},    /* UI_status2 */ \
+  {.msg = {{0x3DF, 1, 8, 2U, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true, .ignore_frequency_check = true}, { 0 }, { 0 }}},    /* UI_status2 */ \
 
 static bool tesla_longitudinal = false;
 static bool tesla_fsd_14 = false;

--- a/opendbc/safety/modes/volvo.h
+++ b/opendbc/safety/modes/volvo.h
@@ -1,0 +1,178 @@
+#pragma once
+
+#include "opendbc/safety/declarations.h"
+
+// Safety-relevant CAN messages for EUCD platform.
+#define VOLVO_EUCD_AccPedal      0x020  // RX, gas pedal
+#define VOLVO_EUCD_FSM0          0x051  // RX from FSM, cruise state
+#define VOLVO_EUCD_VehicleSpeed1 0x148  // RX, vehicle speed
+#define VOLVO_EUCD_Brake_Info    0x20a  // RX, driver brake pressed
+#define VOLVO_EUCD_CCButtons     0x127  // TX by OP, CC buttons
+#define VOLVO_EUCD_PSCM1         0x246  // TX by OP to camera, PSCM state
+#define VOLVO_EUCD_FSM1          0x260  // TX by OP, ACC radar/distance message (oplong)
+#define VOLVO_EUCD_FSM2          0x262  // TX by OP, LKA command
+#define VOLVO_EUCD_FSM3          0x270  // TX by OP, ACC accel request + status
+
+// CAN bus numbers.
+#define VOLVO_MAIN_BUS 0U
+#define VOLVO_AUX_BUS  1U
+#define VOLVO_CAM_BUS  2U
+
+static void volvo_rx_hook(const CANPacket_t *msg) {
+  int addr = msg->addr;
+  if (msg->bus == VOLVO_MAIN_BUS) {
+    if (addr == VOLVO_EUCD_VehicleSpeed1) {
+      // Signal: VehicleSpeed
+      unsigned int speed_raw = (GET_BYTES(msg, 6, 1) << 8) | GET_BYTES(msg, 7, 1);
+      vehicle_moving = speed_raw >= 36U;
+      UPDATE_VEHICLE_SPEED(speed_raw * 0.01 / 3.6);
+    }
+
+    if (addr == VOLVO_EUCD_AccPedal) {
+      // Signal: AccPedal
+      unsigned int gas_raw = ((GET_BYTES(msg, 2, 1) & 0x03U) << 8) | GET_BYTES(msg, 3, 1);
+      gas_pressed = gas_raw >= 100U;
+    }
+
+    if (addr == VOLVO_EUCD_Brake_Info) {
+      // Signal: BrakePedal
+      brake_pressed = ((GET_BYTES(msg, 2, 1) & 0x0CU) >> 2U) == 2U;
+    }
+
+    if (addr == VOLVO_EUCD_PSCM1) {
+      // Signal: SteeringAngleServo (16-bit big-endian, bytes 2-3, factor 0.0447, offset -1465 deg).
+      // Stored as angle_deg * 100 to match VOLVO_STEERING_LIMITS.angle_deg_to_can in the tx hook.
+      unsigned int angle_raw = (GET_BYTES(msg, 2, 1) << 8) | GET_BYTES(msg, 3, 1);
+      int angle_meas_new = ROUND(((angle_raw * 0.0447f) - 1465.0f) * 100.0f);
+      update_sample(&angle_meas, angle_meas_new);
+    }
+  } else if (msg->bus == VOLVO_CAM_BUS) {
+    if (addr == VOLVO_EUCD_FSM0) {
+      // Signal: ACC_Enabled (bit 2 of byte 2, from ACCStatus == 6 || 7)
+      bool cruise_engaged = (GET_BYTES(msg, 2, 1) & 0x04U) != 0U;
+      pcm_cruise_check(cruise_engaged);
+    }
+  } else {
+    // no other bus is monitored
+  }
+}
+
+static bool volvo_tx_hook(const CANPacket_t *msg) {
+  // FSM3 byte1 = ACC_AccelerationRequest (factor 0.04, offset -5.04); raw_accel = byte1 - 126.
+  // +50 raw = +2.0 m/s^2 max accel; -100 raw = -4.0 m/s^2 max decel.
+  const LongitudinalLimits VOLVO_LONG_LIMITS = {
+    .max_accel = 50,
+    .min_accel = -100,
+    .inactive_accel = 0,
+  };
+
+  // Angle steering limits — mirror CarControllerParams.ANGLE_LIMITS in values.py.
+  // angle_deg_to_can = 100 so desired_angle / angle_meas are carried as angle_deg * 100.
+  const AngleSteeringLimits VOLVO_STEERING_LIMITS = {
+    .max_angle = 9000,  // 90 deg
+    .angle_deg_to_can = 100,
+    .angle_rate_up_lookup = {
+      {0., 5., 15.},
+      {5., .8, .15}
+    },
+    .angle_rate_down_lookup = {
+      {0., 5., 15.},
+      {5., 3.5, .4}
+    },
+    // OP sends LKAAngleReq=0 with LKASteerDirection=NONE when not steering, so the
+    // commanded angle must be exactly zero while disabled (not near the measurement).
+    .inactive_angle_is_zero = true,
+  };
+
+  bool tx = true;
+  bool violation = false;
+  int addr = msg->addr;
+
+  // Safety check for CC button signals.
+  if (addr == VOLVO_EUCD_CCButtons) {
+    // Violation if resume button is pressed while controls not allowed, or
+    // if cancel button is pressed when cruise isn't engaged.
+    violation |= !cruise_engaged_prev && (GET_BIT(msg, 59U) || !(GET_BIT(msg, 43U)));  // Signals: ACCOnOffBtn, ACCOnOffBtnInv (cancel)
+    violation |= !controls_allowed && (GET_BIT(msg, 61U) || !(GET_BIT(msg, 45U)));  // Signals: ACCResumeBtn, ACCResumeBtnInv (resume)
+  }
+
+  // Safety check for Lane Keep Assist action.
+  if (addr == VOLVO_EUCD_FSM2) {
+    // Signal: LKAAngleReq (14-bit big-endian over bytes 3-4, factor 0.04, offset -327.68 deg).
+    // raw*0.04 - 327.68 deg, carried here as angle_deg * 100 => raw*4 - 32768.
+    unsigned int angle_raw = ((GET_BYTES(msg, 3, 1) & 0x3FU) << 8) | GET_BYTES(msg, 4, 1);
+    int desired_angle = ((int)angle_raw * 4) - 32768;
+
+    // Gate on angle command, not LKASteerDirection: EUCD needs ~8-frame NONE pause on
+    // direction change while OP still emits a tracking angle — gating direction would stall lat.
+    bool steer_control_enabled = controls_allowed || controls_allowed_lateral;
+
+    if (steer_angle_cmd_checks(desired_angle, steer_control_enabled, VOLVO_STEERING_LIMITS)) {
+      violation = true;
+    }
+  }
+
+  // Longitudinal control: gate on controls_allowed + range check.
+  // check_relay=false lets stock FSM3 flow cam->main; OP overlays only when long-active.
+  if (addr == VOLVO_EUCD_FSM3) {
+    int raw_accel = (int)GET_BYTES(msg, 1, 1) - 126;
+    // When controls are not allowed, only the inactive (neutral) accel is permitted so OP
+    // can relay stock FSM3 at 50Hz without faulting the ECU. When controls are allowed,
+    // enforce the standard accel range.
+    bool accel_violation = controls_allowed ? longitudinal_accel_checks(raw_accel, VOLVO_LONG_LIMITS)
+                                             : (raw_accel != VOLVO_LONG_LIMITS.inactive_accel);
+    if (accel_violation) {
+      violation = true;
+    }
+  }
+
+  if (violation) {
+    tx = false;
+  }
+
+  return tx;
+}
+
+static bool volvo_fwd_hook(int bus_num, int addr) {
+  bool block_msg = false;
+  // Block stock FSM1/FSM3 cam->main when controls_allowed so OP relays at 50Hz
+  // and ACC_Check=1 isn't overwritten by stock's ACC_Check=0 during SNG.
+  if (((unsigned int)bus_num == VOLVO_CAM_BUS) && controls_allowed && !gas_pressed) {
+    if ((addr == VOLVO_EUCD_FSM1) || (addr == VOLVO_EUCD_FSM3)) {
+      block_msg = true;  // OP relays via create_radar/create_longitudinal
+    }
+  }
+  return block_msg;
+}
+
+static safety_config volvo_init(uint16_t param) {
+  (void)param;
+
+  static const CanMsg VOLVO_EUCD_TX_MSGS[] = {
+    {VOLVO_EUCD_CCButtons, VOLVO_MAIN_BUS, 8, .check_relay = false},
+    {VOLVO_EUCD_PSCM1,     VOLVO_CAM_BUS,  8, .check_relay = true},   // OP replaces stock steering servo state
+    {VOLVO_EUCD_FSM2,      VOLVO_MAIN_BUS, 8, .check_relay = true},   // OP replaces stock LKA command
+    // FSM1/FSM3: check_relay=false — ECM validates a rolling counter; passthrough delay
+    // causes ECM fault (~30s, drive 27). Stock flows untouched; OP's later TX wins via last-message-wins.
+    {VOLVO_EUCD_FSM1,      VOLVO_MAIN_BUS, 8, .check_relay = false},
+    {VOLVO_EUCD_FSM3,      VOLVO_MAIN_BUS, 8, .check_relay = false},
+  };
+
+  // TODO: add counters
+  static RxCheck volvo_eucd_rx_checks[] = {
+    {.msg = {{VOLVO_EUCD_AccPedal,      VOLVO_MAIN_BUS, 8, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true, .frequency = 100U}, { 0 }, { 0 }}},
+    {.msg = {{VOLVO_EUCD_FSM0,          VOLVO_CAM_BUS,  8, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true, .frequency = 100U}, { 0 }, { 0 }}},
+    {.msg = {{VOLVO_EUCD_VehicleSpeed1, VOLVO_MAIN_BUS, 8, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true, .frequency = 50U}, { 0 }, { 0 }}},
+    {.msg = {{VOLVO_EUCD_Brake_Info,    VOLVO_MAIN_BUS, 8, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true, .frequency = 50U}, { 0 }, { 0 }}},
+    {.msg = {{VOLVO_EUCD_PSCM1,         VOLVO_MAIN_BUS, 8, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true, .frequency = 50U}, { 0 }, { 0 }}},  // steering angle meas
+  };
+
+  return BUILD_SAFETY_CFG(volvo_eucd_rx_checks, VOLVO_EUCD_TX_MSGS);
+}
+
+const safety_hooks volvo_hooks = {
+  .init = volvo_init,
+  .rx = volvo_rx_hook,
+  .tx = volvo_tx_hook,
+  .fwd = volvo_fwd_hook,
+};

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -27,6 +27,7 @@
 #include "opendbc/safety/modes/elm327.h"
 #include "opendbc/safety/modes/body.h"
 #include "opendbc/safety/modes/psa.h"
+#include "opendbc/safety/modes/volvo.h"
 #include "opendbc/safety/modes/hyundai_canfd.h"
 
 uint32_t GET_BYTES(const CANPacket_t *msg, int start, int len) {
@@ -416,6 +417,7 @@ int set_safety_hooks(uint16_t mode, uint16_t param) {
 #ifdef ALLOW_DEBUG
     {SAFETY_CHRYSLER_CUSW, &chrysler_cusw_hooks},
     {SAFETY_PSA, &psa_hooks},
+    {SAFETY_VOLVO, &volvo_hooks},
     {SAFETY_SUBARU_PREGLOBAL, &subaru_preglobal_hooks},
     {SAFETY_VOLKSWAGEN_MLB, &volkswagen_mlb_hooks},
     {SAFETY_VOLKSWAGEN_PQ, &volkswagen_pq_hooks},

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -333,7 +333,7 @@ void safety_tick(const safety_config *cfg) {
       }
 
       // enforce minimum frequency for safety-relevant messages
-      bool frequency_invalid = frequency < 10U;
+      bool frequency_invalid = !cfg->rx_checks[i].msg[cfg->rx_checks[i].status.index].ignore_frequency_check && (frequency < 10U);
       if (lagging || frequency_invalid || !is_msg_valid(cfg->rx_checks, i)) {
         rx_checks_invalid = true;
         controls_allowed = false;

--- a/opendbc/safety/sunnypilot/mads.h
+++ b/opendbc/safety/sunnypilot/mads.h
@@ -120,6 +120,7 @@ inline void m_update_control_state(void) {
     } else if (m_mads_state.braking.current) {
       allowed = false;
     } else {
+      // no action: brake is neither rising, falling, nor currently pressed
     }
   }
 

--- a/opendbc/safety/tests/test.sh
+++ b/opendbc/safety/tests/test.sh
@@ -25,7 +25,11 @@ fi
 if [ "$1" == "--report" ]; then
   mkdir -p coverage-out
   gcovr -r ../ --gcov-executable "$GCOV_EXEC" --html-nested coverage-out/index.html
-  sensible-browser coverage-out/index.html
+  if [ "$(uname)" = "Darwin" ]; then
+    open coverage-out/index.html
+  else
+    sensible-browser coverage-out/index.html
+  fi
 fi
 
 # test coverage

--- a/opendbc/safety/tests/test_volvo.py
+++ b/opendbc/safety/tests/test_volvo.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+import unittest
+
+import numpy as np
+
+from opendbc.car.structs import CarParams
+from opendbc.safety.tests.libsafety import libsafety_py
+import opendbc.safety.tests.common as common
+from opendbc.safety.tests.common import CANPackerSafety
+
+
+class TestVolvoSafety(common.CarSafetyTest, common.AngleSteeringSafetyTest):
+
+  TX_MSGS = [[0x127, 0], [0x260, 0], [0x262, 0], [0x270, 0], [0x246, 2]]
+  GAS_PRESSED_THRESHOLD = 10
+  STANDSTILL_THRESHOLD = 0.1
+  RELAY_MALFUNCTION_ADDRS = {0: [0x262], 2: [0x246]}
+  FWD_BLACKLISTED_ADDRS = {2: [0x262], 0: [0x246]}
+
+  VOLVO_MAIN_BUS = 0
+  #VOLVO_AUX_BUS = 1
+  VOLVO_CAM_BUS = 2
+
+  # Angle control limits
+  STEER_ANGLE_MAX = 90  # deg, matches CarControllerParams.ANGLE_LIMITS
+  DEG_TO_CAN = 100
+
+  ANGLE_RATE_BP = [0., 5., 15.]
+  ANGLE_RATE_UP = [5., .8, .15]  # windup limit
+  ANGLE_RATE_DOWN = [5., 3.5, .4]  # unwind limit
+
+  def setUp(self):
+    self.packer = CANPackerSafety("volvo_v60_2015_pt")
+    self.safety = libsafety_py.libsafety
+    self.safety.set_safety_hooks(CarParams.SafetyModel.volvo, 0)
+    self.safety.init_tests()
+
+  def _angle_cmd_msg(self, angle: float, enabled: bool):
+    # LKAAngleReq carries the signed angle the safety rate-limits. LKASteerDirection is the
+    # car's per-frame actuation gate (set here for realism) but is NOT used by the safety to
+    # decide engagement — it drops to NONE during the anti-windup pause while OP stays engaged.
+    direction = (2 if angle > 0 else 1) if enabled else 0
+    values = {"LKAAngleReq": angle, "LKASteerDirection": direction}
+    return self.packer.make_can_msg_safety("FSM2", self.VOLVO_MAIN_BUS, values)
+
+  def _angle_meas_msg(self, angle: float):
+    values = {"SteeringAngleServo": angle}
+    return self.packer.make_can_msg_safety("PSCM1", self.VOLVO_MAIN_BUS, values)
+
+  def _pcm_status_msg(self, enable):
+    values = {"ACC_Enabled": 1 if enable else 0}
+    return self.packer.make_can_msg_safety("FSM0", self.VOLVO_CAM_BUS, values)
+
+  def _speed_msg(self, speed: float):
+    values = {"VehicleSpeed": speed * 3.6}
+    return self.packer.make_can_msg_safety("VehicleSpeed1", self.VOLVO_MAIN_BUS, values)
+
+  def _user_brake_msg(self, brake):
+    values = {"BrakePedal": 2 if brake else 0}
+    return self.packer.make_can_msg_safety("Brake_Info", self.VOLVO_MAIN_BUS, values)
+
+  def _user_gas_msg(self, gas):
+    values = {"AccPedal": 10 if gas else 0}
+    return self.packer.make_can_msg_safety("AccPedal", self.VOLVO_MAIN_BUS, values)
+
+  def _vehicle_moving_msg(self, speed: float):
+    values = {"VehicleSpeed": 0 if speed <= self.STANDSTILL_THRESHOLD else 10}
+    return self.packer.make_can_msg_safety("VehicleSpeed1", 0, values)
+
+  def _longitudinal_cmd_msg(self, accel: float):
+    values = {"ACC_AccelerationRequest": accel, "ACC_Check": 0}
+    return self.packer.make_can_msg_safety("FSM3", self.VOLVO_MAIN_BUS, values)
+
+  def test_longitudinal_relay_when_controls_not_allowed(self):
+    # OP relays FSM3 at 50Hz even when controls are not allowed (to keep the ECU alive).
+    # The safety hook must allow inactive accel (0.0) and block any non-zero accel.
+    self.safety.set_controls_allowed(False)
+    self.assertTrue(self._tx(self._longitudinal_cmd_msg(0.0)))    # neutral — must pass
+    self.assertFalse(self._tx(self._longitudinal_cmd_msg(1.0)))   # any accel — must be blocked
+    self.assertFalse(self._tx(self._longitudinal_cmd_msg(-1.0)))  # any decel — must be blocked
+
+  def test_longitudinal_accel_limits_when_controls_allowed(self):
+    # When controls are allowed, FSM3 accel is range-checked via longitudinal_accel_checks.
+    self.safety.set_controls_allowed(True)
+    self.assertTrue(self._tx(self._longitudinal_cmd_msg(0.0)))   # neutral — must pass
+    self.assertTrue(self._tx(self._longitudinal_cmd_msg(2.0)))   # max accel — must pass
+    self.assertTrue(self._tx(self._longitudinal_cmd_msg(-4.0)))  # max decel — must pass
+    self.assertFalse(self._tx(self._longitudinal_cmd_msg(2.1)))  # above max accel — must block
+    self.assertFalse(self._tx(self._longitudinal_cmd_msg(-4.1))) # below min accel — must block
+
+  def test_fwd_hook_blocks_fsm_when_controls_allowed(self):
+    # When controls are allowed and gas is not pressed, OP relays FSM1/FSM3 itself,
+    # so stock cam→main messages for those addrs must be blocked.
+    for controls_allowed in (True, False):
+      for gas_pressed in (True, False):
+        self.safety.set_controls_allowed(controls_allowed)
+        self._rx(self._user_gas_msg(gas_pressed))
+        for addr in (0x260, 0x270):  # VOLVO_EUCD_FSM1, VOLVO_EUCD_FSM3
+          result = self.safety.safety_fwd_hook(self.VOLVO_CAM_BUS, addr)
+          should_block = controls_allowed and not gas_pressed
+          expected = -1 if should_block else self.VOLVO_MAIN_BUS
+          self.assertEqual(expected, result, f"{addr=:#x} {controls_allowed=} {gas_pressed=}")
+
+  # Volvo gates the angle command on engagement, not on the LKASteerDirection flag (which
+  # drops to NONE mid-control during the anti-windup pause), and uses inactive_angle_is_zero:
+  # while engaged the rate-limited angle is allowed, while disengaged only a zero angle passes.
+  # The two methods below mirror AngleSteeringSafetyTest but adjust those expectations.
+  def test_angle_cmd_when_disabled(self):
+    for controls_allowed in (True, False):
+      self.safety.set_controls_allowed(controls_allowed)
+
+      for angle_meas in np.arange(-90, 91, 10):
+        self._reset_angle_measurement(angle_meas)
+
+        for angle_cmd in np.arange(-90, 91, 10):
+          self._set_prev_desired_angle(angle_cmd)
+
+          # engaged: angle (held at prev) is allowed; disengaged: only a zero angle passes
+          should_tx = controls_allowed or (angle_cmd == 0)
+          self.assertEqual(should_tx, self._tx(self._angle_cmd_msg(angle_cmd, True)))
+
+  def test_angle_cmd_when_enabled(self):
+    # when controls are allowed, angle cmd rate limit is enforced
+    speeds = [0., 1., 5., 10., 15., 50.]
+    if self.STEER_ANGLE_TEST_MAX is None:
+        self.STEER_ANGLE_TEST_MAX = self.STEER_ANGLE_MAX * 2
+    angles = np.concatenate((np.arange(-self.STEER_ANGLE_TEST_MAX, self.STEER_ANGLE_TEST_MAX, 5), [0]))
+    for a in angles:
+      for s in speeds:
+        max_delta_up = np.interp(s, self.ANGLE_RATE_BP, self.ANGLE_RATE_UP)
+        max_delta_down = np.interp(s, self.ANGLE_RATE_BP, self.ANGLE_RATE_DOWN)
+
+        # first test against false positives
+        self._reset_angle_measurement(a)
+        self._reset_speed_measurement(s)
+
+        self._set_prev_desired_angle(a)
+        self.safety.set_controls_allowed(1)
+
+        # Stay within limits
+        # Up
+        self.assertTrue(self._tx(self._angle_cmd_msg(a + common.sign_of(a) * max_delta_up, True)))
+        self.assertTrue(self.safety.get_controls_allowed())
+
+        # Don't change
+        self.assertTrue(self._tx(self._angle_cmd_msg(a, True)))
+        self.assertTrue(self.safety.get_controls_allowed())
+
+        # Down
+        self.assertTrue(self._tx(self._angle_cmd_msg(a - common.sign_of(a) * max_delta_down, True)))
+        self.assertTrue(self.safety.get_controls_allowed())
+
+        # Inject too high rates
+        # Up
+        self.assertFalse(self._tx(self._angle_cmd_msg(a + common.sign_of(a) * (max_delta_up + 1.1), True)))
+
+        # Don't change
+        self.safety.set_controls_allowed(1)
+        self._set_prev_desired_angle(a)
+        self.assertTrue(self.safety.get_controls_allowed())
+        self.assertTrue(self._tx(self._angle_cmd_msg(a, True)))
+        self.assertTrue(self.safety.get_controls_allowed())
+
+        # Down
+        self.assertFalse(self._tx(self._angle_cmd_msg(a - common.sign_of(a) * (max_delta_down + 1.1), True)))
+
+        # When disabled, only a zero angle is allowed (inactive_angle_is_zero)
+        self.safety.set_controls_allowed(0)
+        self.assertEqual(a == 0, self._tx(self._angle_cmd_msg(a, False)))
+
+if __name__ == "__main__":
+  unittest.main()

--- a/opendbc/sunnypilot/car/car_list.json
+++ b/opendbc/sunnypilot/car/car_list.json
@@ -4477,5 +4477,23 @@
       "2023"
     ],
     "package": "Adaptive Cruise Control (ACC) & Lane Assist"
+  },
+  "Volvo V60 2010-18": {
+    "platform": "VOLVO_V60",
+    "make": "Volvo",
+    "brand": "volvo",
+    "model": "V60",
+    "year": [
+      "2010",
+      "2011",
+      "2012",
+      "2013",
+      "2014",
+      "2015",
+      "2016",
+      "2017",
+      "2018"
+    ],
+    "package": "Adaptive Cruise Control & Lane Keeping Aid"
   }
 }

--- a/opendbc/sunnypilot/car/volvo/icbm.py
+++ b/opendbc/sunnypilot/car/volvo/icbm.py
@@ -1,0 +1,58 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+
+from opendbc.car import structs, DT_CTRL
+from opendbc.car.can_definitions import CanData
+from opendbc.car.common.conversions import Conversions as CV
+from opendbc.car.volvo import volvocan
+from opendbc.car.volvo.values import CarControllerParams
+from opendbc.sunnypilot.car.intelligent_cruise_button_management_interface_base import IntelligentCruiseButtonManagementInterfaceBase
+
+SendButtonState = structs.IntelligentCruiseButtonManagement.SendButtonState
+
+# Volvo ACC buttons change speed in 5 km/h steps (always to the next multiple
+# of 5). Floor the planner target to the nearest 5 km/h multiple so the
+# high-level controller stops pressing once cruise reaches that floor, instead
+# of oscillating between two multiples (e.g. target=93 → floor=90 → hold at 90
+# rather than bouncing between 90 and 95).
+ACC_STEP_KMH = 5
+
+BUTTONS = {
+  SendButtonState.increase: {"set_plus": True},
+  SendButtonState.decrease: {"minus": True},
+}
+
+
+class IntelligentCruiseButtonManagementInterface(IntelligentCruiseButtonManagementInterfaceBase):
+  def __init__(self, CP, CP_SP):
+    super().__init__(CP, CP_SP)
+
+  def update(self, CC_SP, CS, packer, frame, last_button_frame) -> list[CanData]:
+    can_sends = []
+    self.CC_SP = CC_SP
+    self.ICBM = CC_SP.intelligentCruiseButtonManagement
+    self.frame = frame
+    self.last_button_frame = last_button_frame
+
+    send = self.ICBM.sendButton
+
+    if send != SendButtonState.none:
+      # vTarget is already in km/h (set by controller.py after MS_TO_KPH conversion)
+      floor_target_kph = int(self.ICBM.vTarget // ACC_STEP_KMH) * ACC_STEP_KMH
+      cruise_kph = round(CS.out.cruiseState.speedCluster * CV.MS_TO_KPH)
+
+      if send == SendButtonState.increase and cruise_kph >= floor_target_kph:
+        send = SendButtonState.none
+      elif send == SendButtonState.decrease and cruise_kph <= floor_target_kph:
+        send = SendButtonState.none
+
+    if send != SendButtonState.none:
+      if (self.frame - self.last_button_frame) * DT_CTRL > 0.2:
+        can_sends.extend([volvocan.create_button_msg(packer, **BUTTONS[send])] * CarControllerParams.BUTTON_BURST)
+        self.last_button_frame = self.frame
+
+    return can_sends


### PR DESCRIPTION
<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID: 1a659bbcb3d24b75
* Route: 00000641--39552419d4
Harness for Volvo is custom, available here: https://xnor.shop/products/volvo-p3-harness

ADD Volvo V60/S60 to Sunnypilot
Works only for P3 platform from 2015 to 2017
It requires model with ACC and LKA
Do not work for 2014 or older because of hydraulic steering
Do not work for 2018 or newer because it's flexray
Do not work for XC60 because it's hydraulic steering
Angle is very limited, about 15 degrees, so it's mainly only for highway
Do not include longitudinal control, it's stocklong, but it includes ICBM
Also includes full stop and go during traffic jam
