### PR TITLE
hyundai: relabel Tucson GEN as gasoline and add N7035 camera firmware

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1176,16 +1176,18 @@ FW_VERSIONS = {
   },
   CAR.HYUNDAI_TUCSON_2025: {
     (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00NX4 FR_CMR AT GEN LHD 1.00 1.00 99211-N7030 C55',
+      b'\xf1\x00NX4 FR_CMR AT GEN LHD 1.00 1.00 99211-N7035 C5C',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.01 99211-N7050 C5A',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
+      b'\xf1\x00NX4__               1.00 1.02 99110N7000          ',
       b'\xf1\x00NX4__               1.00 1.03 99110N7100          ',
     ],
   },
   CAR.HYUNDAI_TUCSON_HEV_2025: {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00NX4 FR_CMR AT EUR LHD 1.00 1.00 99211-N7030 C55',
-      b'\xf1\x00NX4 FR_CMR AT GEN LHD 1.00 1.00 99211-N7030 C55',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N7030 C55',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [


### PR DESCRIPTION
## Summary

Two related fixes for the Hyundai Tucson NX4 GEN-region (Korean market) MY2026:

- **Relabel:** Move GEN-region fwdCamera `99211-N7030 C55` and the matching `99110N7000 1.00 1.02` radar from `HYUNDAI_TUCSON_HEV_2025` to `HYUNDAI_TUCSON_2025`. The GEN variant is gasoline, not hybrid (confirmed by the owner with VIN `KMHJB81BHTU402650`, model year code T = 2026). EUR/USA `N7030 C55` entries remain in `HYUNDAI_TUCSON_HEV_2025` since those are confirmed hybrid.
- **Fix dealer-flashed firmware:** Add new fwdCamera string `99211-N7035 C5C GEN LHD` which is flashed by Hyundai dealers on the same MY2026 GEN gasoline Tucson. This breaks the existing exact-match (the `C5C` part-number/check-digits do not exist in any current platform), causing `car_fingerprint: None` and forcing users to manually set a `FIXED_FINGERPRINT`.

### Context

This is a follow-up to #468 which added the GEN-region camera. After the dealer flash, the camera string changed from `99211-N7030 C55` to `99211-N7035 C5C` on the same vehicle. Confirmed via live FW dump on the device.

Since the platforms `HYUNDAI_TUCSON_2025`, `HYUNDAI_TUCSON_HEV_2025`, and `HYUNDAI_TUCSON_PHEV_2025` all share identical `CarSpecs` (mass, wheelbase, steerRatio) and CCNC flag, and longitudinal tuning is driven by `HyundaiFlags.CANFD` (not `HYBRID`), the relabel is purely informational and does not change driving behavior. It does correct the displayed brand/model in the UI and docs.

## Verification

Simulated exact FW match using `match_fw_to_car_exact` on representative scenarios:

| Scenario | FW | Expected platform | Match |
| --- | --- | --- | --- |
| Owner pre-update (gasoline GEN) | `N7030 C55 GEN` + `N7000 1.02` | `HYUNDAI_TUCSON_2025` | ✅ |
| Owner post-update (gasoline GEN) | `N7035 C5C GEN` + `N7000 1.02` | `HYUNDAI_TUCSON_2025` | ✅ |
| Hybrid USA | `N7030 C55 USA` + `N7100 1.02` | `HYUNDAI_TUCSON_HEV_2025` | ✅ |
| Hybrid EUR | `N7030 C55 EUR` + `N7100 1.03` | `HYUNDAI_TUCSON_HEV_2025` | ✅ |
| Tucson 2025 USA original | `N7050 C5A USA` + `N7100 1.03` | `HYUNDAI_TUCSON_2025` | ✅ |
| PHEV CAN | `N7030 C55 CAN` + `N7100 1.02` | `HYUNDAI_TUCSON_PHEV_2025` | ✅ |

All six scenarios yield exactly one match. No platform collisions.