### PR TITLE
Rivian: remove leftover 0.5 scaling on radar yRel

### DIFF
--- a/opendbc/car/rivian/radar_interface.py
+++ b/opendbc/car/rivian/radar_interface.py
@@ -66,7 +66,7 @@ class RadarInterface(RadarInterfaceBase):
         self.pts[addr].measured = msg['STATE'] in (2, 3)
         azimuth = math.radians(msg['AZIMUTH'])
         self.pts[addr].dRel = math.cos(azimuth) * msg['LONG_DIST']
-        self.pts[addr].yRel = 0.5 * -math.sin(azimuth) * msg['LONG_DIST']
+        self.pts[addr].yRel = -math.sin(azimuth) * msg['LONG_DIST']
         self.pts[addr].vRel = msg['REL_SPEED']
         self.pts[addr].aRel = float('nan')
         self.pts[addr].yvRel = float('nan')


### PR DESCRIPTION
The radar parser was copied from Hyundai. It has a 0.5 on yRel that I forgot to remove.
In the Rivian DBC the angle is in degrees (0.1°/bit) and the distance is in meters, so the math is just:

```
dRel = cos(azimuth) · dist
yRel = -sin(azimuth) · dist      # without 0.5
```
The 0.5 halved the y position of every radar point.

The factor is probably only needed for Hyundai, where AZIMUTH is scaled 0.2°/bit. There it roughly cancels the doubled angle (sin(2θ) ≈ 2·sin(θ))