### PR TITLE
safety/mads: reset heartbeat mismatch counter so a re-engage is not revoked

### DIFF
--- a/opendbc/safety/sunnypilot/mads.h
+++ b/opendbc/safety/sunnypilot/mads.h
@@ -172,6 +172,11 @@ inline void mads_exit_controls(const DisengageReason reason) {
     m_mads_state.controls_requested_lateral = false;
     controls_allowed_lateral = false;
   }
+  // A heartbeat-mismatch exit leaves the counter saturated. Without a reset, a re-engage
+  // that lands between 1Hz ticks is killed on the very next tick, before the heartbeat
+  // flag can catch up, and the TX rejections that follow put counter gaps on the bus
+  // (observed on Rivian: EPAS AngleControlCntr fault -> EAC fault + ToiFlt latch).
+  heartbeat_engaged_mads_mismatches = 0U;
 }
 
 inline void mads_state_update(const bool op_vehicle_moving, const bool op_acc_main, const bool op_allowed, const bool is_braking, const bool _steering_disengage) {

--- a/opendbc/safety/sunnypilot/mads.h
+++ b/opendbc/safety/sunnypilot/mads.h
@@ -88,6 +88,15 @@ inline void m_update_control_state(void) {
       (m_mads_state.mads_button.transition == MADS_EDGE_RISING) ||
       (m_mads_state.op_controls_allowed.transition == MADS_EDGE_RISING)) {
     m_mads_state.controls_requested_lateral = true;
+    // A fresh engage request means any heartbeat mismatch accumulated against the *previous*
+    // engage is stale, so give this one a full grace window. Mirrors the rising-edge reset of
+    // controls_allowed in safety.h. Without this, a disengage followed by a re-engage inside the
+    // 3-tick heartbeat window is killed by the pending mismatch tick: controls_allowed_lateral is
+    // still set when the request arrives (so the grant below does not consume it), then
+    // mads_exit_controls() drops both controls_allowed_lateral and the pending request. Nothing
+    // can re-request after that, so the safety sits lateral-off while openpilot MADS is enabled,
+    // until openpilot's own lateral mismatch watchdog immediate-disables 2s later.
+    heartbeat_engaged_mads_mismatches = 0U;
   }
 
   // Primary control blockers - these prevent any further control processing

--- a/opendbc/safety/tests/mads_common.py
+++ b/opendbc/safety/tests/mads_common.py
@@ -408,6 +408,29 @@ class MadsSafetyTestBase(unittest.TestCase):
     self.assertTrue(self.safety.get_controls_allowed_lateral(),
                     "Counter should have reset; 2 mismatches after reset should not disengage")
 
+  def test_heartbeat_engaged_mads_reengage_after_mismatch(self):
+    """A heartbeat-mismatch exit must reset the mismatch counter, so a re-engage that lands
+    before the heartbeat flag catches up gets a fresh 3-tick grace window instead of an
+    instant revoke on its first tick."""
+    self.safety.set_mads_params(True, False, False)
+
+    # Engage lateral, then force a mismatch-triggered exit (3 mismatches).
+    self.safety.set_controls_allowed_lateral(True)
+    self.safety.set_heartbeat_engaged_mads(False)
+    for _ in range(3):
+      self.safety.mads_heartbeat_engaged_check()
+    self.assertFalse(self.safety.get_controls_allowed_lateral(),
+                     "Should disengage after 3 mismatches")
+
+    # Re-engage while the heartbeat flag is still lagging (false).
+    self.safety.set_controls_allowed_lateral(True)
+
+    # One tick with heartbeat still false must NOT instantly revoke: the counter must have
+    # been reset on the previous exit, giving a fresh grace window.
+    self.safety.mads_heartbeat_engaged_check()
+    self.assertTrue(self.safety.get_controls_allowed_lateral(),
+                    "Re-engage revoked on first tick; stale mismatch counter not reset on exit")
+
   def test_mads_button_not_engaged_without_press(self):
     """Test that MADS button in idle state does not engage lateral control"""
     try:

--- a/opendbc/safety/tests/mads_common.py
+++ b/opendbc/safety/tests/mads_common.py
@@ -431,6 +431,37 @@ class MadsSafetyTestBase(unittest.TestCase):
     self.assertTrue(self.safety.get_controls_allowed_lateral(),
                     "Re-engage revoked on first tick; stale mismatch counter not reset on exit")
 
+  def test_heartbeat_engaged_mads_reengage_before_mismatch_exit(self):
+    """A real re-engage that lands while the mismatch counter is already partly saturated must
+    get a fresh 3-tick grace window. Otherwise the pending tick revokes the brand new engage and
+    nothing can re-request it, leaving the safety lateral-off while openpilot MADS is on (which
+    openpilot punishes with a 2s lateral controls mismatch immediate disable)."""
+    self.safety.set_mads_params(True, False, False)
+
+    # Engage via the MADS button, then disengage on the openpilot side only (heartbeat goes false
+    # while the safety still has lateral granted) -- this is what a stalk-based disengage looks like.
+    self.safety.set_mads_button_press(1)
+    self._rx(self._speed_msg(0))
+    self.assertTrue(self.safety.get_controls_allowed_lateral())
+    self.safety.set_mads_button_press(0)
+    self._rx(self._speed_msg(0))
+
+    self.safety.set_heartbeat_engaged_mads(False)
+    for _ in range(2):
+      self.safety.mads_heartbeat_engaged_check()
+    self.assertTrue(self.safety.get_controls_allowed_lateral(),
+                    "Should still be engaged after 2 mismatches")
+
+    # Driver presses the MADS button again before the 3rd tick. The request is real, but lateral is
+    # still granted (no grant edge to consume it) and the heartbeat flag has not caught up yet.
+    self.safety.set_mads_button_press(1)
+    self._rx(self._speed_msg(0))
+    self.assertTrue(self.safety.get_controls_allowed_lateral())
+
+    self.safety.mads_heartbeat_engaged_check()
+    self.assertTrue(self.safety.get_controls_allowed_lateral(),
+                    "Fresh engage revoked by a stale mismatch counter; counter not reset on request")
+
   def test_mads_button_not_engaged_without_press(self):
     """Test that MADS button in idle state does not engage lateral control"""
     try:


### PR DESCRIPTION
## Summary

`heartbeat_engaged_mads_mismatches` is never cleared on the two paths that should clear it, which makes a MADS re-engage near a heartbeat-mismatch tick get revoked. There are **two halves** to this race, one commit each. Both are **general MADS bugs** affecting every brand that uses the heartbeat engaged check, not brand-specific.

### Half 1 — re-engage lands *after* the mismatch exit (commit 1)

`mads_exit_controls` does not reset the counter, so a heartbeat-mismatch exit leaves it saturated at `3`. The next re-engage that lands **between two 1 Hz firmware ticks** — before `heartbeat_engaged_mads` catches up — is revoked on its very first `mads_heartbeat_engaged_check()` (`3 -> 4 >= 3`), instead of getting a fresh 3-tick grace window.

Fix: one line at the end of `mads_exit_controls`:

```c
heartbeat_engaged_mads_mismatches = 0U;
```

### Half 2 — re-engage lands *before* the mismatch exit (commit 2)

This case is worse: it leaves lateral **permanently** revoked rather than briefly.

When a re-engage arrives while `controls_allowed_lateral` is still set, the grant block's `!controls_allowed_lateral` guard skips, so `controls_requested_lateral` is never consumed and just sits pending. The next heartbeat tick then fires `mads_exit_controls()`, which drops **both** `controls_allowed_lateral` and that pending request. No edge remains that can re-request lateral, so the safety stays lateral-off while openpilot MADS is enabled. openpilot's own watchdog (`lateral_mismatch_counter >= 200` in `mads.py`) then immediate-disables 2 s later with a red "Controls Mismatch: Lateral".

Fix: reset the counter on the rising edge of `controls_requested_lateral`, mirroring the existing guard in `safety.h`:

```c
// reset mismatches on rising edge of controls_allowed to avoid rare race condition
if (controls_allowed && !controls_allowed_prev) {
  heartbeat_engaged_mismatches = 0;
}
```

Neither fix weakens the watchdog: if openpilot is genuinely not engaged, the counter re-accumulates from zero and the safety revokes 3 ticks later.

## How it was found

Both halves were observed in the field on Rivian, where the MADS disengage gesture (stalk past detent) disengages MADS on the openpilot side without a corresponding safety-side exit — so the mismatch window is entered on **every** such disengage, and a driver re-engaging within ~3 s hits it.

**Half 1** is destructive on Rivian: the in-flight lateral TX frames sent during the one-tick revoke are safety-rejected, putting counter gaps on the bus that latch an EPAS `AngleControlCntr` fault (`EAC fault` + `ToiFlt` -> `steerFaultPermanent`, "TAKE CONTROL IMMEDIATELY").

Frame-by-frame replay of the field route `c17ea97dc5472650/00000006` seg 3 through the compiled safety model:

| | TX mismatches vs field | Behaviour in the fault window (t≈222 s) |
|---|---|---|
| **Before** (no reset) | **0** (reproduces field firmware bit-exactly, 117,595 frames) | re-engage at t=221.95 revoked 0.1 s later at t=222.05 → 8 `0x110` frames blocked → EPAS fault |
| **After** (reset) | **8** on `0x110` (`field_blocked=True, replay_blocked=False`) | re-engage survives; the 8 frames pass → fault prevented |

**Half 2** was found later in route `4440a486580ed7c6/00000059` seg 0, on a build that already had the half-1 fix. Log timeline:

| t (s) | Event |
|---|---|
| 21.26 | MADS button → openpilot MADS on; safety grants `controls_allowed_lateral` |
| 21.32 | stalk past detent → openpilot MADS **off**; safety keeps lateral granted |
| ~21.4–23.2 | mismatch counter ticks 1, 2 |
| 23.28 | driver re-presses MADS button → openpilot MADS **on**; request pends, is not consumed |
| ~23.28 | 3rd tick → `mads_exit_controls()` drops lateral **and** the pending request |
| 25.28 | openpilot `lateral_mismatch_counter` hits 200 → `controlsMismatchLateral` immediate disable |

## Testing

Two regression tests in `mads_common.py`, both running for every MADS brand via `CarSafetyTest`, **each verified to fail without its fix and pass with it**:

- `test_heartbeat_engaged_mads_reengage_after_mismatch` — saturates the counter with a mismatch exit, re-engages, asserts the next tick does not instantly revoke.
- `test_heartbeat_engaged_mads_reengage_before_mismatch_exit` — engages, ticks the counter to 2, re-engages while lateral is still granted, asserts the 3rd tick does not revoke. Drives the engage through `set_mads_button_press()` rather than `_lkas_button_msg()`: Subaru's `mads_button_press` is sticky (set on HUD state 1-3, never cleared), so it cannot produce the second rising edge this test needs.

Full safety suite green across all brands: **7578 passed, 3126 skipped**. MISRA was not run locally (cppcheck has no Darwin/x86_64 build) — relying on CI for that.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
