### PR TITLE
Honda - B (regen) gear MADS support

### DIFF
--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -21,7 +21,7 @@ class CarInterface(CarInterfaceBase):
   CarController = CarController
   RadarInterface = RadarInterface
 
-  DRIVABLE_GEARS = (structs.CarState.GearShifter.sport,)
+  DRIVABLE_GEARS = (structs.CarState.GearShifter.sport, structs.CarState.GearShifter.brake,)
 
   @staticmethod
   def get_pid_accel_limits(CP, CP_SP, current_speed, cruise_speed):

--- a/opendbc/dbc/generator/honda/_gearbox_common.dbc
+++ b/opendbc/dbc/generator/honda/_gearbox_common.dbc
@@ -34,8 +34,8 @@ CM_ SG_ 419 REGEN_STAGE_SELECTION "Driver-selected regenerative braking threshol
 CM_ SG_ 419 REGEN_MEMORY "Driver-selected persistence setting, M shown in instrument cluster";
 CM_ SG_ 419 REGEN_UNKNOWN "Both bits set when user enables regen, otherwise zero";
 
-VAL_ 401 GEAR_SHIFTER 1 "P" 2 "R" 3 "N" 4 "D" 7 "L" 10 "S";
-VAL_ 419 GEAR_SHIFTER 1 "P" 2 "R" 3 "N" 4 "D" 7 "L" 10 "S";
+VAL_ 401 GEAR_SHIFTER 1 "P" 2 "R" 3 "N" 4 "D" 7 "L" 10 "S" 11 "B";
+VAL_ 419 GEAR_SHIFTER 1 "P" 2 "R" 3 "N" 4 "D" 7 "L" 10 "S" 11 "B";
 VAL_ 419 TRANS_TARGET_GEAR 0 "None / Neutral / Park" 1 "1st" 2 "2nd" 3 "3rd" 4 "4th" 5 "5th" 6 "6th" 7 "7th" 8 "8th" 9 "9th" 10 "10th" 13 "Reverse";
 VAL_ 419 REGEN_STAGE_SELECTION 0 "disabled" 1 "stage_1" 2 "stage_2" 3 "stage_3" 4 "stage_4" 5 "stage_5" 6 "stage_6";
 VAL_ 419 REGEN_MEMORY 0 "disabled" 1 "persistent";

--- a/opendbc/sunnypilot/car/honda/carstate_ext.py
+++ b/opendbc/sunnypilot/car/honda/carstate_ext.py
@@ -32,3 +32,6 @@ class CarStateExt:
       # Same threshold as panda, equivalent to 1e-5 with previous DBC scaling
       gas = (cp.vl["GAS_SENSOR"]["INTERCEPTOR_GAS"] + cp.vl["GAS_SENSOR"]["INTERCEPTOR_GAS2"]) // 2
       ret.gasPressed = gas > 492
+
+    if ret.gearShifter == GearShifter.brake
+      ret.brakePressed = True # allows MADS in B (regen braking) mode

--- a/opendbc/sunnypilot/car/honda/carstate_ext.py
+++ b/opendbc/sunnypilot/car/honda/carstate_ext.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 
 from opendbc.car import Bus, structs
 from opendbc.can.parser import CANParser
+from opendbc.car.honda.values import GearShifter
 from opendbc.sunnypilot.car.honda.values_ext import HondaFlagsSP
 
 

--- a/opendbc/sunnypilot/car/honda/carstate_ext.py
+++ b/opendbc/sunnypilot/car/honda/carstate_ext.py
@@ -33,5 +33,5 @@ class CarStateExt:
       gas = (cp.vl["GAS_SENSOR"]["INTERCEPTOR_GAS"] + cp.vl["GAS_SENSOR"]["INTERCEPTOR_GAS2"]) // 2
       ret.gasPressed = gas > 492
 
-    if ret.gearShifter == GearShifter.brake
+    if ret.gearShifter == GearShifter.brake:
       ret.brakePressed = True # allows MADS in B (regen braking) mode


### PR DESCRIPTION
Allows MADS to function in B (regen) gear.

Factory B gear acts like a regen-powered brake, blocking ACC but allowing LKAS.  This change allows Sunnypilot to operate MADS in regen gear.

Testdrive successful, testroute coming.