### PR TITLE
safety: update MADS state once per RX frame

### DIFF
--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -205,6 +205,8 @@ bool safety_rx_hook(const CANPacket_t *msg) {
   // Handles gas, brake, and regen paddle
   generic_rx_checks();
 
+  mads_state_update(vehicle_moving, acc_main_on, controls_allowed, brake_pressed || regen_braking, steering_disengage);
+
   // the relay malfunction hook runs on all incoming rx messages.
   // check all applicable tx msgs for liveness on sending bus.
   // used to detect a relay malfunction or control messages from disabled ECUs like the radar
@@ -383,7 +385,6 @@ static void stock_ecu_check(bool stock_ecu_detected) {
   if ((safety_mode_cnt > RELAY_TRNS_TIMEOUT) && stock_ecu_detected) {
     relay_malfunction_set();
   }
-  mads_state_update(vehicle_moving, acc_main_on, controls_allowed, brake_pressed || regen_braking, steering_disengage);
 }
 
 static void relay_malfunction_reset(void) {


### PR DESCRIPTION
Move the MADS state update out of stock_ecu_check so it runs once after generic RX checks instead of once per relay-checked TX message.

This change ensures mads_state_update() runs exactly once per received CAN frame, after the vehicle-specific and generic RX checks have updated the shared safety state. Previously, it was called once for every relay-checked TX message, causing redundant work inside the CAN RX interrupt handler.
Removing these repeated updates shortens the interrupt handler and reduces overall interrupt load. This allows time-sensitive SPI interrupts to be serviced sooner, reducing SPI timing contention and potentially lowering the occurrence of NACKs under high CAN traffic.
